### PR TITLE
Add plugin annotation to URL

### DIFF
--- a/planet_explorer/gui/mosaic_layer_widget.py
+++ b/planet_explorer/gui/mosaic_layer_widget.py
@@ -61,7 +61,7 @@ PLANET_MOSAIC_PROC = "planet/mosaicProc"
 PLANET_MOSAIC_RAMP = "planet/mosaicRamp"
 PLANET_MOSAIC_DATATYPE = "planet/mosaicDatatype"
 
-TILE_URL_TEMPLATE = "https://tiles.planet.com/basemaps/v1/planet-tiles/%s/gmap/{z}/{x}/{y}.png?api_key=%s"
+TILE_URL_TEMPLATE = "https://tiles.planet.com/basemaps/v1/planet-tiles/%s/gmap/{z}/{x}/{y}.png?plugin=qgis_v1&api_key=%s"
 
 class CustomSlider(QSlider):
 

--- a/planet_explorer/planet_api/apikey_replacer.py
+++ b/planet_explorer/planet_api/apikey_replacer.py
@@ -37,8 +37,8 @@ PLANET_ROOT_URL = "planet.com"
 PLANET_ROOT_URL_PLACEHOLDER = "{planet_url}"
 
 def is_planet_layer(url):
-    loggedInPattern = re.compile(r".*&url=https://tiles[0-3]?\.planet\.com/.*?api_key=.*")
-    loggedOutPattern = re.compile(r".*&url=https://tiles[0-3]?\.\{planet_url\}/.*?api_key=.*")
+    loggedInPattern = re.compile(r".*&url=https://tiles[0-3]?\.planet\.com/.*?.*api_key=.*")
+    loggedOutPattern = re.compile(r".*&url=https://tiles[0-3]?\.\{planet_url\}/.*?.*api_key=.*")
     isloggedInPattern = loggedInPattern.search(url) is not None
     isloggedOutPattern = loggedOutPattern.search(url) is not None
 

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -75,7 +75,7 @@ ITEM_GROUPS = [
 QUOTA_URL = 'https://api.planet.com/auth/v1/experimental' \
             '/public/my/subscriptions'
 
-TILE_SERVICE_URL = 'https://tiles{0}.planet.com/data/v1/layers'
+TILE_SERVICE_URL = 'https://tiles{0}.planet.com/data/v1/layers?plugin=qgis_v1'
 
 class LoginException(Exception):
     """Issues raised during client login"""


### PR DESCRIPTION
The main idea is to add `?plugin=qgis_v1` to all tile requests that hit Planet tile servers. This is helpful because it lets us monitor which versions of the plugin are being used.