### PR TITLE
Bump version number so we can publish a new version of the plugin

### DIFF
--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -7,7 +7,7 @@
 name=Planet_Explorer
 qgisMinimumVersion=3.6
 description=The Planet Plugin enables QGIS users to quickly discover, stream, and download Planet imagery and Planet Basemaps. The plug-in provides an imagery discovery interface that allows users to search for, stream, and download Planet imagery within QGIS.<br><br>Full documentation for the Plugin is available <a href="https://developers.planet.com/docs/integrations/qgis/">here</a>.
-version=1.2
+version=1.3
 author=Planet Inc
 email=qgis-plugin@planet.com
 

--- a/qgis3-conda-forge-env.yml
+++ b/qgis3-conda-forge-env.yml
@@ -25,5 +25,5 @@ dependencies:
   - shapely=1.6.4
   - sphinx=2.2.0
   - pip:
-    - qgiscommons==2.0.12
-    - sentry-sdk=0.12.3
+      - qgiscommons==2.0.12
+      - sentry-sdk==0.12.3


### PR DESCRIPTION
Victor's latest change is important enough that we should bump the version

also an unrelated tiny patch to use == instead of = so that pip can recognize the version properly