### PR TITLE
Add an install workflow job for testing plugin install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         qgis_version: [ release-3_10, release-3_16, latest ]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
+      # cf https://docs.qgis.org/3.16/en/docs/user_manual/introduction/qgis_configuration.html#running-qgis-with-advanced-settings
       QGIS_COMMAND: qgis --noplugins --noversioncheck --nologo --version-migration --code ./planet_explorer/tests/install_plugin.py
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,35 @@ jobs:
       with:
         name: planet_explorer_${{github.sha}}
         path: tmp
+
+  install:
+    name: "Install"
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        qgis_version: [ release-3_10, release-3_16, latest ]
+    env:
+      QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
+      QGIS_COMMAND: qgis --noplugins --noversioncheck --nologo --version-migration --code ./planet_explorer/tests/install_plugin.py
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: planet_explorer_${{github.sha}}
+          path: tmp
+
+      - name: Zip artifact
+        run: (cd tmp && zip -r ../planet_explorer_${{github.sha}}.zip .)
+
+      - name: Pull qgis image
+        run: docker pull qgis/qgis:${QGIS_TEST_VERSION}
+
+      - name: Run install test
+        run: docker run --rm -v `pwd`:/tests_directory -t -w /tests_directory qgis/qgis:${QGIS_TEST_VERSION} sh -c "xvfb-run ${QGIS_COMMAND}"

--- a/planet_explorer/tests/install_plugin.py
+++ b/planet_explorer/tests/install_plugin.py
@@ -7,6 +7,10 @@ Install a plugin from a zip file into QGIS. This script is meant to be run insid
     qgis --noplugins --code install_plugin.py
 
 The package zip file for the plugin is expected to be present in current working directory.
+
+Verifies:
+    - PLQGIS-TC01
+    - PLQGIS-TC02
 """
 import os
 import pathlib
@@ -17,9 +21,24 @@ class PluginInstallException(Exception):
     pass
 
 
+ERROR_OCCURRED = False
+ERROR_MSG = ""
+
+
+def error_catcher(msg, tag, level):
+    """
+    Catch a python error and raise a PluginInstallException
+    """
+    global ERROR_OCCURRED, ERROR_MSG
+    if tag == "Python error" and level != 0:
+        ERROR_OCCURRED = True
+        ERROR_MSG = msg
+
+
 try:
     try:
         import pyplugin_installer
+        from qgis.core import QgsApplication
     except ImportError:
         raise PluginInstallException(
             "Cannot install plugin as 'pyplugin_installer' could not be imported."
@@ -41,16 +60,30 @@ try:
 
     plugin_install_zip = zip_files[0]
     plugin_installer = pyplugin_installer.instance()
+    # Make sure plugin is not installed
+    assert (
+        "planet_explorer" not in pyplugin_installer.installer_data.plugins.all().keys()
+    ), "Planet plugin is already installed!"
+
+    # Attach the error catcher
+    QgsApplication.messageLog().messageReceived.connect(error_catcher)
 
     # Install from the zip file
     plugin_installer.installFromZipFile(str(plugin_install_zip.absolute()))
-    assert "planet_explorer" in pyplugin_installer.installer_data.plugins.all().keys()
+    assert (
+        "planet_explorer" in pyplugin_installer.installer_data.plugins.all().keys()
+    ), "Planet plugin failed to install!"
+
+    if ERROR_OCCURRED:
+        raise PluginInstallException(
+            f"Python exception hit during plugin install: \n {ERROR_MSG}"
+        )
 
     # Uninstall the plugin
     plugin_installer.uninstallPlugin("planet_explorer", quiet=True)
     assert (
         "planet_explorer" not in pyplugin_installer.installer_data.plugins.all().keys()
-    )
+    ), "Planet plugin failed to uninstall!"
 except Exception:  # noqa
     # Print the error so we know where it failed,
     # and exit with a non-zero status code so CI will fail.

--- a/planet_explorer/tests/install_plugin.py
+++ b/planet_explorer/tests/install_plugin.py
@@ -84,6 +84,11 @@ try:
     assert (
         "planet_explorer" not in pyplugin_installer.installer_data.plugins.all().keys()
     ), "Planet plugin failed to uninstall!"
+
+    if ERROR_OCCURRED:
+        raise PluginInstallException(
+            f"Python exception hit during plugin uninstall: \n {ERROR_MSG}"
+        )
 except Exception:  # noqa
     # Print the error so we know where it failed,
     # and exit with a non-zero status code so CI will fail.

--- a/planet_explorer/tests/install_plugin.py
+++ b/planet_explorer/tests/install_plugin.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+"""
+Install a plugin from a zip file into QGIS. This script is meant to be run inside of QGIS:
+
+.. code-block:: bash
+
+    qgis --noplugins --code install_plugin.py
+
+The package zip file for the plugin is expected to be present in current working directory.
+"""
+import os
+import pathlib
+import traceback
+
+
+class PluginInstallException(Exception):
+    pass
+
+
+try:
+    try:
+        import pyplugin_installer
+    except ImportError:
+        raise PluginInstallException(
+            "Cannot install plugin as 'pyplugin_installer' could not be imported."
+            " Is the script running in the QGIS env?"
+        )
+
+    zip_files = [file for file in pathlib.Path("./").glob("*.zip")]
+
+    if not zip_files:
+        raise PluginInstallException(
+            f"ERROR: No plugin zip file found at {pathlib.Path('./').absolute()}."
+        )
+
+    if len(zip_files) > 1:
+        raise PluginInstallException(
+            f"ERROR: More than one plugin zip file found at {pathlib.Path('./').absolute()}."
+            f" Found {[str(f) for f in zip_files]}."
+        )
+
+    plugin_install_zip = zip_files[0]
+    plugin_installer = pyplugin_installer.instance()
+
+    # Install from the zip file
+    plugin_installer.installFromZipFile(str(plugin_install_zip.absolute()))
+    assert "planet_explorer" in pyplugin_installer.installer_data.plugins.all().keys()
+
+    # Uninstall the plugin
+    plugin_installer.uninstallPlugin("planet_explorer", quiet=True)
+    assert (
+        "planet_explorer" not in pyplugin_installer.installer_data.plugins.all().keys()
+    )
+except Exception:  # noqa
+    # Print the error so we know where it failed,
+    # and exit with a non-zero status code so CI will fail.
+    print("FAIL: Plugin install and uninstalled failed with the following:")
+    print(traceback.format_exc())
+    os._exit(1)
+finally:
+    # The install and uninstall worked! Exit QGIS with a 0 status code.
+    print(
+        f"PASS: Plugin install and uninstall successful for {str(plugin_install_zip)}"
+    )
+    os._exit(0)


### PR DESCRIPTION
- Add an `install` workflow job, this job will take the uploaded asset from the `build` job and attempt to install it into the qgis docker container
- Add a test script to handle the installation/uninstallation of the uploaded asset

I tested this install script in the following ways:
- with a dummy zip file
- with a plugin zip that contains an error (in this case just a bad import) 
- with a plugin zip that contains no errors

The behavior of the script was correct in all cases. 