### PR TITLE
Ensure download for unit tests

### DIFF
--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -251,10 +251,11 @@ class OrderItemWidget(QWidget):
 
         self.setLayout(layout)
 
-    def download(self):
+    def download(self, is_unit_test=False):
         for task in QgsApplication.taskManager().activeTasks():
             if (
-                isinstance(task, OrderProcessorTask)
+                not is_unit_test
+                and isinstance(task, OrderProcessorTask)
                 and task.order.id() == self.order.id()
             ):
                 iface.messageBar().pushMessage(
@@ -264,7 +265,7 @@ class OrderItemWidget(QWidget):
                     duration=5,
                 )
                 return
-        if self.order.downloaded():
+        if not is_unit_test and self.order.downloaded():
             ret = QMessageBox.question(
                 self,
                 "Download order",
@@ -333,10 +334,11 @@ class QuadsOrderItemWidget(QWidget):
 
         self.setLayout(layout)
 
-    def download(self):
+    def download(self, is_unit_test=False):
         for task in QgsApplication.taskManager().activeTasks():
             if (
-                isinstance(task, QuadsOrderProcessorTask)
+                not is_unit_test
+                and isinstance(task, QuadsOrderProcessorTask)
                 and task.order.id() == self.order.id()
             ):
                 iface.messageBar().pushMessage(
@@ -346,7 +348,7 @@ class QuadsOrderItemWidget(QWidget):
                     duration=5,
                 )
                 return
-        if self.order.downloaded():
+        if not is_unit_test and self.order.downloaded():
             ret = QMessageBox.question(
                 self,
                 "Download order",

--- a/planet_explorer/tests/test_basemaps.py
+++ b/planet_explorer/tests/test_basemaps.py
@@ -250,5 +250,5 @@ def test_basemaps_order_partial(
         ), f"New order not present in orders list: {order_names}"
 
         # Download the basemap
-        item_widget.download()  # noqa
+        item_widget.download(is_unit_test=True)  # noqa
         qtbot.waitUntil(item_widget.order.downloaded, timeout=60 * 1000)  # noqa

--- a/planet_explorer/tests/test_orders.py
+++ b/planet_explorer/tests/test_orders.py
@@ -95,7 +95,7 @@ def test_order_download(
     # CI trying to download multiple orders at the same time posed problems.
     if qgis_version > 32600:
         # TODO: better workaround?
-        order_item_widget.download()
+        order_item_widget.download(is_unit_test=True)
         qtbot.waitUntil(order_item.order.downloaded, timeout=60 * 1000)
 
 


### PR DESCRIPTION
To avoid a premature `return`, pass a flag to make sure the download actually happens. This should help with some of the flakiness we've been seeing with this test. 