### PR TITLE
Add to map function

### DIFF
--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -453,19 +453,17 @@ class OrderItemWidget(QWidget):
                         # The raster specified in the manifest.json file is missing
                         self.qgs_error_message(
                             "Cannot add data to map",
-                            "Image layer is missing",
-                            60
+                            "Image layer is missing"
                         )
         else:
             # The manifest.json file is missing
             # This file contains information on the downloaded data
             self.qgs_error_message(
                 "Cannot add data to map",
-                "Manifest file is missing",
-                60
+                "Manifest file is missing"
             )
 
-    def qgs_error_message(self, error_title='Error', error_desciption='', timeout=0):
+    def qgs_error_message(self, error_title='Error', error_desciption=''):
         """Displays an error message on the QGIS message bar. A buttons is included which will open
         a message box.
 
@@ -474,53 +472,13 @@ class OrderItemWidget(QWidget):
 
         :param error_desciption: Error message description
         :type error_desciption: str
-
-        :param timeout: Message bar timeout in seconds. 0 is infinite.
-        :type timeout: int
         """
 
         message_bar = iface.messageBar()
-
-        msg_widget = message_bar.createMessage(
+        message_bar.pushInfo(
             error_title,
-            error_desciption
+            message=error_desciption
         )
-
-        details_btn = QPushButton(msg_widget)
-        details_btn.setText("Details")
-        details_btn.pressed.connect(self.details_btn_clicked)
-        msg_widget.layout().addWidget(details_btn)
-
-        message_bar.pushWidget(
-            msg_widget,
-            level=Qgis.Warning,
-            duration=timeout
-        )
-
-    def details_btn_clicked(self):
-        """Opens a QMessageBox when the Details button is clicked. The aim of this is to help the user at
-        finding the error on why the data cannot be added to the map
-        """
-
-        message_box = QMessageBox()
-        message_box.setIcon(QMessageBox.NoIcon)
-        message_box.setWindowTitle("Cannot add data to map")
-        message_box.setText("INFORMATION ON HOW TO FIX THE PROBLEM")
-
-        folder_btn = message_box.addButton('Order folder', QMessageBox.ActionRole)
-        folder_btn.setIcon(QIcon(FOLDER_ICON))
-        folder_btn.clicked.connect(
-            lambda: QDesktopServices.openUrl(
-                QUrl.fromLocalFile(self.order.download_folder())
-            )
-        )
-
-        help_btn = message_box.addButton('Online help', QMessageBox.ActionRole)
-        help_btn.setIcon(QIcon(EXT_LINK))
-
-        message_box.setStandardButtons(QMessageBox.Close)
-
-        return_value = message_box.exec()
 
 
 class QuadsOrderItem(BaseWidgetItem):

--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -23,11 +23,18 @@ __revision__ = "$Format:%H$"
 
 import logging
 import os
+import json
 
 import iso8601
 from planet.api.models import Order, Orders
 
-from qgis.core import Qgis, QgsApplication
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsRasterLayer,
+    QgsProject,
+    QgsContrastEnhancement
+)
 
 from qgis.PyQt import uic
 
@@ -43,6 +50,8 @@ from qgis.PyQt.QtWidgets import (
     QPushButton,
     QVBoxLayout,
     QWidget,
+    QSpacerItem,
+    QSizePolicy
 )
 
 from ..pe_utils import orders_download_folder, iface, user_agent
@@ -228,26 +237,40 @@ class OrderItemWidget(QWidget):
         label.setOpenExternalLinks(True)
         if not order.is_zipped():
             label.setStyleSheet("color: gray")
-        button = QPushButton("Re-Download" if order.downloaded() else "Download")
+        # Addition space characters added to Download so that it vertically lines-up neatly with the Re-download button
+        button = QPushButton("Re-Download" if order.downloaded() else "   Download   ")
         button.clicked.connect(self.download)
         button.setEnabled(order.state() == "success" and order.is_zipped())
 
-        vlayout = QVBoxLayout()
-        vlayout.addWidget(button)
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(button)
+
+        add_to_map_btn = QPushButton("Add to map")
+        add_to_map_btn.clicked.connect(self.add_to_map)
+        hlayout.addWidget(add_to_map_btn)
+
         if order.downloaded():
-            labelOpenFolder = QLabel("<a href='#'>Open order folder</a>")
-            vlayout.addWidget(labelOpenFolder)
-            labelOpenFolder.setOpenExternalLinks(False)
-            labelOpenFolder.linkActivated.connect(
+            # Enable the add to map button if the data has been downloaded
+            add_to_map_btn.setEnabled(True)
+
+            # Add the open folder location button if the data has been downloaded
+            label_open_folder = QLabel("<a href='#'>Open order folder</a>")
+            hlayout.addWidget(label_open_folder)
+            label_open_folder.setOpenExternalLinks(False)
+            label_open_folder.linkActivated.connect(
                 lambda: QDesktopServices.openUrl(
                     QUrl.fromLocalFile(self.order.download_folder())
                 )
             )
+        else:
+            # Add to map button will be disabled if the data has not been downloaded
+            add_to_map_btn.setEnabled(False)
+        hlayout.addStretch(1)  # Spacer
 
-        layout = QHBoxLayout()
+        layout = QVBoxLayout()
         layout.addWidget(label)
         layout.addStretch()
-        layout.addLayout(vlayout)
+        layout.addLayout(hlayout)
 
         self.setLayout(layout)
 
@@ -284,6 +307,112 @@ class OrderItemWidget(QWidget):
             level=Qgis.Info,
             duration=5,
         )
+
+    def _find_band(self, layer, name, default):
+        name = name.lower()
+        for i in range(layer.bandCount()):
+            if name == layer.bandName(i).lower().split(": ")[-1]:
+                return i
+        return default
+
+    def load_layer(self, layer):
+
+        band_cnt = layer.bandCount()
+        if band_cnt < 3:
+            # Rasters with less than 3 bands will be added as single band
+            r = layer.renderer().clone()
+            r.setGrayBand(1)
+
+            used_bands = r.usesBands()
+            typ = layer.renderer().dataType(1)
+            enhancement = QgsContrastEnhancement(typ)
+            enhancement.setContrastEnhancementAlgorithm(
+                QgsContrastEnhancement.StretchToMinimumMaximum, True
+            )
+            band_min, band_max = layer.dataProvider().cumulativeCut(
+                used_bands[0], 0.02, 0.98, sampleSize=10000
+            )
+            enhancement.setMinimumValue(band_min)
+            enhancement.setMaximumValue(band_max)
+            r.setContrastEnhancement(enhancement)
+
+            layer.setRenderer(r)
+            QgsProject.instance().addMapLayer(layer)
+        else:
+            # BGR image for 3 or more bands
+            r = layer.renderer().clone()
+            r.setBlueBand(self._find_band(layer, "blue", 1))
+            r.setGreenBand(self._find_band(layer, "green", 2))
+            r.setRedBand(self._find_band(layer, "red", 3))
+
+            used_bands = r.usesBands()
+            for b in range(3):
+                typ = layer.renderer().dataType(b)
+                enhancement = QgsContrastEnhancement(typ)
+                enhancement.setContrastEnhancementAlgorithm(
+                    QgsContrastEnhancement.StretchToMinimumMaximum, True
+                )
+                band_min, band_max = layer.dataProvider().cumulativeCut(
+                    used_bands[b], 0.02, 0.98, sampleSize=10000
+                )
+                enhancement.setMinimumValue(band_min)
+                enhancement.setMaximumValue(band_max)
+                if b == 0:
+                    r.setRedContrastEnhancement(enhancement)
+                elif b == 1:
+                    r.setGreenContrastEnhancement(enhancement)
+                elif b == 2:
+                    r.setBlueContrastEnhancement(enhancement)
+
+            layer.setRenderer(r)
+            QgsProject.instance().addMapLayer(layer)
+
+    def add_to_map(self):
+        message_bar = iface.messageBar()
+
+        order_name = self.order.name().split('_')[0]
+        manifest_dir = '{}/{}_QGIS/{}'.format(
+            self.order.download_folder(),
+            order_name,
+            'manifest.json'
+        )
+
+        if os.path.exists(manifest_dir):
+            manifest_file = open(manifest_dir)
+            manifest_data = json.load(manifest_file)
+
+            list_files = manifest_data['files']
+            for json_file in list_files:
+                media_type = json_file['media_type']
+                if media_type == 'image/tiff':
+                    image_path = json_file['path']
+                    image_dir = '{}/{}_QGIS/{}'.format(
+                        self.order.download_folder(),
+                        order_name,
+                        image_path
+                    )
+
+                    if os.path.exists(image_dir):
+                        layer = QgsRasterLayer(image_dir, os.path.basename(image_dir))
+                        self.load_layer(layer)
+                    else:
+                        # The raster specified in the manifest is missing
+                        message_bar.pushMessage(
+                            'Error',
+                            'Could not find the raster: {}'.format(
+                                image_dir
+                            ),
+                            level=Qgis.Warning
+                        )
+        else:
+            # The manifest is missing
+            message_bar.pushMessage(
+                'Error',
+                'Could not find the manifest: {}'.format(
+                    manifest_dir
+                ),
+                level=Qgis.Warning
+            )
 
 
 class QuadsOrderItem(BaseWidgetItem):


### PR DESCRIPTION
- "Add to map" button has been added to the Orders monitor dock:
![image](https://user-images.githubusercontent.com/79740955/199291463-44cdbbfd-a397-498c-9ab3-26071405734d.png)
- Data will be added as BGR, therefore true colour
- Buttons is now at the bottom of each element, and no longer to the right
- Works for both SkySat and PlanetScope data
- Works for both geotif and nitf formats
- Makes use of the manifest to locate the rasters
- Error messages if the image layer or manifest cannot be found:
![image](https://user-images.githubusercontent.com/79740955/199291727-736d2f8d-51b1-4d01-aa25-6922c44e6553.png)
![image](https://user-images.githubusercontent.com/79740955/199291734-ce0db271-d5dc-4eca-80bf-4237dfa928cc.png)