### PR TITLE
The info drop-down terms button will now take the user to the Planet Terms website

### DIFF
--- a/planet_explorer/pe_plugin.py
+++ b/planet_explorer/pe_plugin.py
@@ -497,9 +497,7 @@ class PlanetExplorer(object):
         add_menu_section_action("Documentation", info_menu)
 
         terms_act = QAction(QIcon(EXT_LINK), "Terms", info_menu)
-        terms_act.triggered[bool].connect(
-            lambda: open_link_with_browser(PLANET_TERMS)
-        )
+        terms_act.triggered[bool].connect(lambda: open_link_with_browser(PLANET_TERMS))
         info_menu.addAction(terms_act)
 
         btn = QToolButton()

--- a/planet_explorer/pe_plugin.py
+++ b/planet_explorer/pe_plugin.py
@@ -124,6 +124,7 @@ PLANET_SUPPORT_COMMUNITY = "https://support.planet.com"
 PLANET_EXPLORER = f"{PLANET_COM}/explorer"
 PLANET_INTEGRATIONS = "https://developers.planet.com/tag/integrations.html"
 PLANET_SALES = "https://www.planet.com/contact-sales"
+PLANET_TERMS = "https://www.planet.com/terms-of-use"
 
 EXT_LINK = ":/plugins/planet_explorer/external-link.svg"
 ACCOUNT_URL = f"{BASE_URL}/account"
@@ -495,8 +496,10 @@ class PlanetExplorer(object):
 
         add_menu_section_action("Documentation", info_menu)
 
-        terms_act = QAction("Terms", info_menu)
-        terms_act.triggered[bool].connect(self.show_terms)
+        terms_act = QAction(QIcon(EXT_LINK), "Terms", info_menu)
+        terms_act.triggered[bool].connect(
+            lambda: open_link_with_browser(PLANET_TERMS)
+        )
         info_menu.addAction(terms_act)
 
         btn = QToolButton()


### PR DESCRIPTION
The "Terms" button can be found under the information drop-down of the plugin:
![image](https://user-images.githubusercontent.com/79740955/200279186-d3f5afbb-f603-4e40-bb06-a8d4a752a7ac.png)
The button will now take the user to the Planet online terms website: https://www.planet.com/terms-of-use/
The icon of this button has been updated with the external link icon.

Website which will open if the user clicks on the button:
![image](https://user-images.githubusercontent.com/79740955/200279446-aa508b5d-532c-4af3-b3d5-c08fd847ccf2.png)
