### PR TITLE
CI tests: Pin pytest until we can update pytest-qt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        qgis_version: [ release-3_10, release-3_16, release-3_22, release-3_24, latest ]
+        qgis_version: [ release-3_10, release-3_16, release-3_24, release-3_26, latest ]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
       # cf https://docs.qgis.org/3.16/en/docs/user_manual/introduction/qgis_configuration.html#running-qgis-with-advanced-settings

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        qgis_version: [release-3_10, release-3_16, release-3_22, release-3_24, latest]
+        qgis_version: [release-3_10, release-3_16, release-3_24, release-3_26, latest]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest==7.1.3
+pytest<=7.1.3
 pytest-qgis
 # Version < 4 required for QGIS 3.10
 pytest-qt<4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==7.1.3
 pytest-qgis
 # Version < 4 required for QGIS 3.10
 pytest-qt<4


### PR DESCRIPTION
Address #62 

- Looks like `pytest-qt` is hitting an issue similar to https://github.com/pytest-dev/pytest-html/pull/555
- We cannot update it until we remove `qgis 3.10` support. So, let's pin `pytest` for now. 

Also, disable running tests on the `release-3_22` tag, it looks like that image is having problems (no module called `qgis`). I just replaced it with the `release-3_26` tag. 