### PR TITLE
Area is now calculated for all AOI cases.

### DIFF
--- a/planet_explorer/ui/pe_aoi_filter_base.ui
+++ b/planet_explorer/ui/pe_aoi_filter_base.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>612</width>
-    <height>85</height>
+    <height>122</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -267,6 +267,16 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblExtentArea">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Total AOI area (sqkm): </string>
+        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
When the user creates/imports an AOI, the "Total AOI area (sqkm): #" will be calculated and displayed in the UI:
![image](https://user-images.githubusercontent.com/79740955/200359470-2ab98136-f295-4fe8-bd03-bcf10d75bce4.png)

These calculations will be done for the following cases:
- Extents
- Draw tool
- Selection tool;
- Uploading of a file
- When the user manually changes the coordinates in the text box
The text will only display when an area is created, and will be set to invisible when the coordinates is cleared or invalid coordinates are provided by the user.