### PR TITLE
Add STAC as a checkout option

### DIFF
--- a/.docker/run-docker-tests.sh
+++ b/.docker/run-docker-tests.sh
@@ -3,6 +3,6 @@
 set -e
 
 pushd /usr/src
-DEFAULT_PARAMS='./planet_explorer/tests/ -v --qgis_disable_gui --qgis_disable_init --reruns 2'
+DEFAULT_PARAMS='./planet_explorer/tests/test_orders.py -k test_order_scene -v --qgis_disable_gui --qgis_disable_init --reruns 2'
 xvfb-run pytest ${@:-`echo $DEFAULT_PARAMS`}
 popd

--- a/planet_explorer/__init__.py
+++ b/planet_explorer/__init__.py
@@ -36,3 +36,4 @@ def classFactory(iface):
     from planet_explorer.pe_plugin import PlanetExplorer
 
     return PlanetExplorer(iface)
+

--- a/planet_explorer/__init__.py
+++ b/planet_explorer/__init__.py
@@ -36,4 +36,3 @@ def classFactory(iface):
     from planet_explorer.pe_plugin import PlanetExplorer
 
     return PlanetExplorer(iface)
-

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -657,6 +657,7 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
         self.txtOrderName.textChanged.connect(self._nameChanged)
         self.btnPlaceOrder.clicked.connect(self._btnPlaceOrderClicked)
         self.btnPlaceOrderReview.clicked.connect(self._btnPlaceOrderClicked)
+        self.btnSTAC.clicked.connec(self._btnSTACClicked)
         self.btnContinueName.clicked.connect(
             lambda: self.stackedWidget.setCurrentIndex(1)
         )
@@ -672,6 +673,9 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
         self.labelPageReview.linkActivated.connect(self._pageLabelClicked)
         self.labelPageAssets.linkActivated.connect(self._pageLabelClicked)
         self.labelPageName.linkActivated.connect(self._pageLabelClicked)
+
+
+        self.stac_order = False
 
         images_dict = defaultdict(list)
         # thumbnails_dict = defaultdict(list)
@@ -738,6 +742,9 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
 
         self.stackedWidget.setEnabled(True)
         self.btnPlaceOrder.setEnabled(True)
+
+    def _btnSTACClicked(self):
+        self.stac_order = not self.stac_order
 
     def selectionChanged(self):
         self.update_review_items()
@@ -835,6 +842,10 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
                 }
                 order["notifications"] = {"email": True}
 
+                if self.stac_order:
+                    order["metadata"] = {
+                        "stac": {}
+                    }
                 tools = []
                 if w.clipping():
                     tools.append({"clip": {"aoi": aoi}})

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -657,7 +657,7 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
         self.txtOrderName.textChanged.connect(self._nameChanged)
         self.btnPlaceOrder.clicked.connect(self._btnPlaceOrderClicked)
         self.btnPlaceOrderReview.clicked.connect(self._btnPlaceOrderClicked)
-        self.btnSTAC.clicked.connec(self._btnSTACClicked)
+        self.btnSTAC.clicked.connect(self._btnSTACClicked)
         self.btnContinueName.clicked.connect(
             lambda: self.stackedWidget.setCurrentIndex(1)
         )

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -637,7 +637,7 @@ class PlanetOrderReviewMetadataWidget(QWidget):
         self.btnSTAC.setFlat(True)
         self.btnSTAC.setText("STAC")
         self.btnSTAC.setToolTip(
-            "Click to enable/disable STAC " "metadata usage in the order."
+            "Click to enable/disable STAC metadata usage in the order."
         )
 
         if self.stac_order:
@@ -652,7 +652,9 @@ class PlanetOrderReviewMetadataWidget(QWidget):
 
         title_label = QLabel("<b> Metadata </b>")
         self.description_label = QLabel(
-            "<a href='https://stacspec.org/'>STAC</a> metadata provides a standardized format for "
+            "<a style='color: #50a94e; text-decoration: none;' "
+            "href='https://stacspec.org/'>STAC</a>"
+            " metadata provides a standardized format for "
             "describing geospatial information so that it can "
             "be more <br> easily worked with in tool like QGIS."
         )

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -589,13 +589,17 @@ class PlanetOrderReviewWidget(QWidget):
 
 class PlanetOrderReviewMetadataWidget(QWidget):
 
-    STAC_ENABLED_ORDER_CSS = "QPushButton { background-color: #074c48; color: white;"\
-                             "border: 3px solid #4eb4ae;"\
-                             "padding: 3px 5px 2px 5px; border-radius: 3px; }"
+    STAC_ENABLED_ORDER_CSS = (
+        "QPushButton { background-color: #074c48; color: white;"
+        "border: 3px solid #4eb4ae;"
+        "padding: 3px 5px 2px 5px; border-radius: 3px; }"
+    )
 
-    STAC_DISABLED_ORDER_CSS = "QPushButton { background-color: none; color: black;"\
-                              "border: 3px solid #4eb4ae;"\
-                              "padding: 3px 5px 2px 5px; border-radius: 3px; }"
+    STAC_DISABLED_ORDER_CSS = (
+        "QPushButton { background-color: none; color: black;"
+        "border: 3px solid #4eb4ae;"
+        "padding: 3px 5px 2px 5px; border-radius: 3px; }"
+    )
 
     stac_metadata_btn_clicked = pyqtSignal()
 
@@ -615,13 +619,9 @@ class PlanetOrderReviewMetadataWidget(QWidget):
         self.btnSTAC.setText("STAC")
 
         if self.stac_order:
-            self.btnSTAC.setStyleSheet(
-                self.STAC_ENABLED_ORDER_CSS
-            )
+            self.btnSTAC.setStyleSheet(self.STAC_ENABLED_ORDER_CSS)
         else:
-            self.btnSTAC.setStyleSheet(
-                self.STAC_DISABLED_ORDER_CSS
-            )
+            self.btnSTAC.setStyleSheet(self.STAC_DISABLED_ORDER_CSS)
         self.btnSTAC.setMinimumHeight(45)
         self.btnSTAC.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.btnSTAC.setMinimumWidth(250)
@@ -655,13 +655,9 @@ class PlanetOrderReviewMetadataWidget(QWidget):
         self.stac_metadata_btn_clicked.emit()
         self.stac_order = not self.stac_order
         if self.stac_order:
-            self.btnSTAC.setStyleSheet(
-                self.STAC_ENABLED_ORDER_CSS
-            )
+            self.btnSTAC.setStyleSheet(self.STAC_ENABLED_ORDER_CSS)
         else:
-            self.btnSTAC.setStyleSheet(
-                self.STAC_DISABLED_ORDER_CSS
-            )
+            self.btnSTAC.setStyleSheet(self.STAC_DISABLED_ORDER_CSS)
 
 
 class PlanetOrderSummaryOrderWidget(QWidget):

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -589,6 +589,14 @@ class PlanetOrderReviewWidget(QWidget):
 
 class PlanetOrderReviewMetadataWidget(QWidget):
 
+    STAC_ENABLED_ORDER_CSS = "QPushButton { background-color: #074c48; color: white;"\
+                             "border: 3px solid #4eb4ae;"\
+                             "padding: 3px 5px 2px 5px; border-radius: 3px; }"
+
+    STAC_DISABLED_ORDER_CSS = "QPushButton { background-color: none; color: black;"\
+                              "border: 3px solid #4eb4ae;"\
+                              "padding: 3px 5px 2px 5px; border-radius: 3px; }"
+
     stac_metadata_btn_clicked = pyqtSignal()
 
     def __init__(self, stac_order):
@@ -608,15 +616,11 @@ class PlanetOrderReviewMetadataWidget(QWidget):
 
         if self.stac_order:
             self.btnSTAC.setStyleSheet(
-                "background-color: #074c48; color: white;"
-                "border: 3px solid #4eb4ae;"
-                "padding: 3px 5px 2px 5px; border-radius: 3px;"
+                self.STAC_ENABLED_ORDER_CSS
             )
         else:
             self.btnSTAC.setStyleSheet(
-                "background-color: none; color: black;"
-                "border: 3px solid #4eb4ae;"
-                "padding: 3px 5px 2px 5px; border-radius: 3px;"
+                self.STAC_DISABLED_ORDER_CSS
             )
         self.btnSTAC.setMinimumHeight(45)
         self.btnSTAC.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
@@ -652,15 +656,11 @@ class PlanetOrderReviewMetadataWidget(QWidget):
         self.stac_order = not self.stac_order
         if self.stac_order:
             self.btnSTAC.setStyleSheet(
-                "background-color: #074c48; color: white;"
-                "border: 3px solid #4eb4ae;"
-                "padding: 3px 5px 2px 5px; border-radius: 3px;"
+                self.STAC_ENABLED_ORDER_CSS
             )
         else:
             self.btnSTAC.setStyleSheet(
-                "background-color: none; color: black;"
-                "border: 3px solid #4eb4ae;"
-                "padding: 3px 5px 2px 5px; border-radius: 3px;"
+                self.STAC_DISABLED_ORDER_CSS
             )
 
 
@@ -849,6 +849,7 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
 
         metadata_widget = PlanetOrderReviewMetadataWidget(self.stac_order)
         metadata_widget.stac_metadata_btn_clicked.connect(self._btnSTACClicked)
+        self.metadata_widget = metadata_widget
         layout.addWidget(metadata_widget)
 
         layout.addStretch()

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -130,7 +130,7 @@ class PlanetOrderBundleWidget(QFrame):
         self.udm = bundle.get("auxiliaryFiles", "").lower().startswith("udm2")
         assets = bundle["assets"]
         self.can_harmonize = (
-                "ortho_analytic_4b_sr" in assets or "ortho_analytic_8b_sr" in assets
+            "ortho_analytic_4b_sr" in assets or "ortho_analytic_8b_sr" in assets
         )
         self.can_harmonize = bundle.get("canHarmonize", False)
         self.can_clip = bundle.get("canClip", False)
@@ -595,8 +595,8 @@ class PlanetOrderReviewMetadataWidget(QWidget):
         super().__init__()
 
         self.stac_order = QSettings().value(
-                f"{SETTINGS_NAMESPACE}/{ENABLE_STAC_METADATA}", False
-            )
+            f"{SETTINGS_NAMESPACE}/{ENABLE_STAC_METADATA}", False
+        )
         self.stac_order = stac_order
 
         layout = QVBoxLayout()
@@ -747,8 +747,8 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
         self.labelPageName.linkActivated.connect(self._pageLabelClicked)
 
         self.stac_order = QSettings().value(
-                f"{SETTINGS_NAMESPACE}/{ENABLE_STAC_METADATA}", False
-            )
+            f"{SETTINGS_NAMESPACE}/{ENABLE_STAC_METADATA}", False
+        )
 
         images_dict = defaultdict(list)
         # thumbnails_dict = defaultdict(list)
@@ -925,9 +925,7 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
                 order["notifications"] = {"email": True}
 
                 if self.stac_order:
-                    order["metadata"] = {
-                        "stac": {}
-                    }
+                    order["metadata"] = {"stac": {}}
                 tools = []
                 if w.clipping():
                     tools.append({"clip": {"aoi": aoi}})

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -656,6 +656,7 @@ class PlanetOrderReviewMetadataWidget(QWidget):
             "describing geospatial information so that it can "
             "be more <br> easily worked with in tool like QGIS."
         )
+        self.description_label.setOpenExternalLinks(True)
 
         gridLayout = QGridLayout()
 

--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -61,6 +61,7 @@ PRODUCT_BUNDLE = "product_bundle"
 STATE = "state"
 DELIVERY = "delivery"
 ARCHIVE_TYPE = "archive_type"
+METADATA = "metadata"
 
 plugin_path = os.path.split(os.path.dirname(__file__))[0]
 
@@ -170,6 +171,9 @@ class OrderWrapper:
 
     def state(self):
         return self.order.get(STATE)
+
+    def metadata(self):
+        return self.order.get(METADATA)
 
     def download_folder(self):
         return os.path.join(orders_download_folder(), "daily", self.id())

--- a/planet_explorer/pe_plugin.py
+++ b/planet_explorer/pe_plugin.py
@@ -456,7 +456,7 @@ class PlanetExplorer(object):
         self.provider.updateLayerWidgets()
         try:
             self.enable_buttons(loggedin)
-        except RuntimeError as error:
+        except RuntimeError:
             pass
 
         if not loggedin:

--- a/planet_explorer/pe_plugin.py
+++ b/planet_explorer/pe_plugin.py
@@ -454,7 +454,11 @@ class PlanetExplorer(object):
 
     def login_changed(self, loggedin):
         self.provider.updateLayerWidgets()
-        self.enable_buttons(loggedin)
+        try:
+            self.enable_buttons(loggedin)
+        except RuntimeError as error:
+            pass
+
         if not loggedin:
             hide_orders_monitor()
             hide_inspector()

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -108,6 +108,7 @@ QGIS_LOG_SECTION_NAME = "Planet"
 ORDERS_DOWNLOAD_FOLDER_SETTING = "ordersPath"
 DEFAULT_ORDERS_FOLDERNAME = "planet_orders"
 ENABLE_CLIP_SETTING = "enableClip"
+ENABLE_STAC_METADATA = "enableStacMetadata"
 ENABLE_HARMONIZATION_SETTING = "enableHarmonization"
 
 BASE_URL = "https://www.planet.com"

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -109,6 +109,7 @@ QGIS_LOG_SECTION_NAME = "Planet"
 ORDERS_DOWNLOAD_FOLDER_SETTING = "ordersPath"
 DEFAULT_ORDERS_FOLDERNAME = "planet_orders"
 ENABLE_CLIP_SETTING = "enableClip"
+ENABLE_STAC_METADATA = "enableStacMetadata"
 ENABLE_HARMONIZATION_SETTING = "enableHarmonization"
 
 BASE_URL = "https://www.planet.com"
@@ -584,36 +585,3 @@ def plugin_version(add_commit=False):
 
 def user_agent():
     return f"qgis-{Qgis.QGIS_VERSION};planet-explorer{plugin_version()}"
-
-
-def qgs_log(
-        message: str,
-        name: str = "qgis_planet_explorer",
-        info: bool = True,
-        notify: bool = True,
-):
-    """ Logs the message into QGIS logs using as the default
-    log instance.
-    If notify_user is True, user will be notified about the log.
-
-    :param message: The log message
-    :type message: str
-
-    :param name: Name of the log instance,
-    :type message: str
-
-    :param info: Whether the message is about info or a
-    warning
-    :type info: bool
-
-    :param notify: Whether to notify user about the log
-    :type notify: bool
-     """
-    level = Qgis.Info if info else Qgis.Warning
-    QgsMessageLog.logMessage(
-        message,
-        name,
-        level=level,
-        notifyUser=notify,
-    )
-

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -57,7 +57,6 @@ from qgis.core import (
     QgsGeometry,
     QgsJsonUtils,
     QgsLayerTree,
-    QgsMessageLog,
     QgsProject,
     QgsRasterLayer,
     QgsRectangle,

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -57,6 +57,7 @@ from qgis.core import (
     QgsGeometry,
     QgsJsonUtils,
     QgsLayerTree,
+    QgsMessageLog,
     QgsProject,
     QgsRasterLayer,
     QgsRectangle,
@@ -108,7 +109,6 @@ QGIS_LOG_SECTION_NAME = "Planet"
 ORDERS_DOWNLOAD_FOLDER_SETTING = "ordersPath"
 DEFAULT_ORDERS_FOLDERNAME = "planet_orders"
 ENABLE_CLIP_SETTING = "enableClip"
-ENABLE_STAC_METADATA = "enableStacMetadata"
 ENABLE_HARMONIZATION_SETTING = "enableHarmonization"
 
 BASE_URL = "https://www.planet.com"
@@ -584,3 +584,36 @@ def plugin_version(add_commit=False):
 
 def user_agent():
     return f"qgis-{Qgis.QGIS_VERSION};planet-explorer{plugin_version()}"
+
+
+def qgs_log(
+        message: str,
+        name: str = "qgis_planet_explorer",
+        info: bool = True,
+        notify: bool = True,
+):
+    """ Logs the message into QGIS logs using as the default
+    log instance.
+    If notify_user is True, user will be notified about the log.
+
+    :param message: The log message
+    :type message: str
+
+    :param name: Name of the log instance,
+    :type message: str
+
+    :param info: Whether the message is about info or a
+    warning
+    :type info: bool
+
+    :param notify: Whether to notify user about the log
+    :type notify: bool
+     """
+    level = Qgis.Info if info else Qgis.Warning
+    QgsMessageLog.logMessage(
+        message,
+        name,
+        level=level,
+        notifyUser=notify,
+    )
+

--- a/planet_explorer/settings.json
+++ b/planet_explorer/settings.json
@@ -22,5 +22,13 @@
     "type": "bool",
     "default": false,
     "group": "Orders"
+  },
+  {
+    "name": "enableStacMetadata",
+    "label": "Enable STAC Metadata tool by default",
+    "description": "Enable STAC Metadata tool by default in orders panel",
+    "type": "bool",
+    "default": false,
+    "group": "Orders"
   }
 ]

--- a/planet_explorer/tests/test_orders.py
+++ b/planet_explorer/tests/test_orders.py
@@ -159,9 +159,7 @@ def test_order_scene(
         ), f"New order not present in orders list: {order_names}"
 
         order_metadata = [order.metadata() for order in orders]
-        stac_metadata = {
-            "stac": {}
-        }
+        stac_metadata = {"stac": {}}
 
         if order_dialog.stac_order:
             assert stac_metadata in order_metadata

--- a/planet_explorer/tests/test_orders.py
+++ b/planet_explorer/tests/test_orders.py
@@ -128,9 +128,9 @@ def test_order_scene(
         qgis_debug_wait(qtbot, qgis_debug_enabled)
 
         # check STAC button state
-        assert not order_dialog.stac_order
-        qtbot.mouseClick(order_dialog.btnSTAC, QtCore.Qt.LeftButton)
-        assert order_dialog.stac_order
+        stac_order = order_dialog.stac_order
+        qtbot.mouseClick(order_dialog.metadata_widget.btnSTAC, QtCore.Qt.LeftButton)
+        assert order_dialog.stac_order != stac_order
 
         # review page and place the order. note we only actually place the order
         # on the latest version of QGIS to keep the total number of orders down.
@@ -146,12 +146,24 @@ def test_order_scene(
     if qgis_version > 32600:
         order_monitor = order_monitor_widget(dock_widget)
         order_names = []
+        orders = []
         for index in range(order_monitor.listOrders.count()):
             item = order_monitor.listOrders.item(index)
             item_widget = order_monitor.listOrders.itemWidget(item)
+            orders.append(item_widget.order)
             if isinstance(item_widget.order, OrderWrapper):
                 order_names.append(item_widget.order.order["name"])
 
         assert any(
             order_name in o_name for o_name in order_names
         ), f"New order not present in orders list: {order_names}"
+
+        order_metadata = [order.metadata() for order in orders]
+        stac_metadata = {
+            "stac": {}
+        }
+
+        if order_dialog.stac_order:
+            assert stac_metadata in order_metadata
+        else:
+            assert stac_metadata not in order_metadata

--- a/planet_explorer/tests/test_orders.py
+++ b/planet_explorer/tests/test_orders.py
@@ -5,6 +5,7 @@ from qgis.PyQt import QtCore
 from planet_explorer.gui.pe_orders import PlanetOrdersDialog
 from planet_explorer.gui.pe_orders_monitor_dockwidget import OrderWrapper
 from planet_explorer.tests.utils import get_random_string
+from planet_explorer.planet_api.p_quad_orders import QuadOrder
 
 
 from planet_explorer.tests.utils import qgis_debug_wait
@@ -158,7 +159,11 @@ def test_order_scene(
             order_name in o_name for o_name in order_names
         ), f"New order not present in orders list: {order_names}"
 
-        order_metadata = [order.metadata() for order in orders]
+        # Check for all order metadata except QuadOrder orders
+        order_metadata = [
+            order.metadata() if not isinstance(order, QuadOrder) else None
+            for order in orders
+        ]
         stac_metadata = {"stac": {}}
 
         if order_dialog.stac_order:

--- a/planet_explorer/tests/test_orders.py
+++ b/planet_explorer/tests/test_orders.py
@@ -127,6 +127,11 @@ def test_order_scene(
         qtbot.mouseClick(order_dialog.btnContinueAssets, QtCore.Qt.LeftButton)
         qgis_debug_wait(qtbot, qgis_debug_enabled)
 
+        # check STAC button state
+        assert not order_dialog.stac_order
+        qtbot.mouseClick(order_dialog.btnSTAC, QtCore.Qt.LeftButton)
+        assert order_dialog.stac_order
+
         # review page and place the order. note we only actually place the order
         # on the latest version of QGIS to keep the total number of orders down.
         if qgis_version > 32600:

--- a/planet_explorer/ui/pe_orders.ui
+++ b/planet_explorer/ui/pe_orders.ui
@@ -237,8 +237,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>86</width>
-                 <height>16</height>
+                 <width>100</width>
+                 <height>30</height>
                 </rect>
                </property>
               </widget>
@@ -308,48 +308,6 @@
                  <height>717</height>
                 </rect>
                </property>
-               <widget class="QLabel" name="laSTACDescription">
-                <property name="geometry">
-                 <rect>
-                  <x>150</x>
-                  <y>280</y>
-                  <width>491</width>
-                  <height>121</height>
-                 </rect>
-                </property>
-                <property name="text">
-                 <string>STAC metadata provides a standardized format for describing geospatial information so that it can be more easily worked with in tool like QGIS </string>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-               </widget>
-               <widget class="QLabel" name="laSTACTitle">
-                <property name="geometry">
-                 <rect>
-                  <x>340</x>
-                  <y>250</y>
-                  <width>131</width>
-                  <height>16</height>
-                 </rect>
-                </property>
-                <property name="text">
-                 <string>METADATA</string>
-                </property>
-               </widget>
-               <widget class="QPushButton" name="btnSTAC">
-                <property name="geometry">
-                 <rect>
-                  <x>290</x>
-                  <y>420</y>
-                  <width>191</width>
-                  <height>41</height>
-                 </rect>
-                </property>
-                <property name="text">
-                 <string>STAC</string>
-                </property>
-               </widget>
               </widget>
              </widget>
             </item>

--- a/planet_explorer/ui/pe_orders.ui
+++ b/planet_explorer/ui/pe_orders.ui
@@ -337,7 +337,7 @@
                  <string>METADATA</string>
                 </property>
                </widget>
-               <widget class="QPushButton" name="stacButton">
+               <widget class="QPushButton" name="btnSTAC">
                 <property name="geometry">
                  <rect>
                   <x>290</x>

--- a/planet_explorer/ui/pe_orders.ui
+++ b/planet_explorer/ui/pe_orders.ui
@@ -141,7 +141,7 @@
         <item>
          <widget class="QStackedWidget" name="stackedWidget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>2</number>
           </property>
           <widget class="QWidget" name="pageName">
            <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -237,8 +237,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>895</width>
-                 <height>726</height>
+                 <width>86</width>
+                 <height>16</height>
                 </rect>
                </property>
               </widget>
@@ -304,10 +304,52 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>895</width>
-                 <height>726</height>
+                 <width>808</width>
+                 <height>717</height>
                 </rect>
                </property>
+               <widget class="QLabel" name="laSTACDescription">
+                <property name="geometry">
+                 <rect>
+                  <x>150</x>
+                  <y>280</y>
+                  <width>491</width>
+                  <height>121</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>STAC metadata provides a standardized format for describing geospatial information so that it can be more easily worked with in tool like QGIS </string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+               <widget class="QLabel" name="laSTACTitle">
+                <property name="geometry">
+                 <rect>
+                  <x>340</x>
+                  <y>250</y>
+                  <width>131</width>
+                  <height>16</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>METADATA</string>
+                </property>
+               </widget>
+               <widget class="QPushButton" name="stacButton">
+                <property name="geometry">
+                 <rect>
+                  <x>290</x>
+                  <y>420</y>
+                  <width>191</width>
+                  <height>41</height>
+                 </rect>
+                </property>
+                <property name="text">
+                 <string>STAC</string>
+                </property>
+               </widget>
               </widget>
              </widget>
             </item>
@@ -461,8 +503,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>225</width>
-             <height>337</height>
+             <width>312</width>
+             <height>325</height>
             </rect>
            </property>
           </widget>


### PR DESCRIPTION
These changes enabled using STAC metadata as an option when making orders.

The current behaviour is user enable the STAC metadata option by clicking `STAC` button and can disable it by re-clicking the same button.
This behaviour is per delivered from the below mockup.
![image](https://user-images.githubusercontent.com/2663775/200415012-7f28e571-29e1-43b8-94f3-dcbb659445df.png)

Although this achieves the intended outcome, I'm advising to use a checkbox instead of a button and will make the change if it is confirmed.

Screenshot
![stac_checkout_option](https://user-images.githubusercontent.com/2663775/200415639-7b062024-e19a-4909-8669-887ba16b922a.gif)
