### PR TITLE
Show area of interest size

### DIFF
--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -458,8 +458,20 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
             layer = QgsVectorLayer(filename, "")
             self.aoi_from_layer(layer)
 
+    def show_aoi_area_size(self):
+        """ Displays the aoi area size in square kilometers.
+        """
+
+        area_size_sqkm = self.calculate_aoi_area()
+
+        formatted_area_sq = "{:,}".format(round(area_size_sqkm, 2))
+
+        self.laAOISize.setText(
+            f"Total AOI area (sqkm): {formatted_area_sq}"
+        )
+
     def calculate_aoi_area(self):
-        """ Calculate and display the current aoi area in square kilometers """
+        """ Calculate the current aoi area in square kilometers """
 
         geometry = self.aoi_as_4326_geom()
         area = QgsDistanceArea()
@@ -476,11 +488,8 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
             QgsUnitTypes.AreaSquareKilometers
         )
 
-        formatted_area_sq = "{:,}".format(round(geometry_area_sq, 2))
+        return geometry_area_sq
 
-        self.laAOISize.setText(
-            f"Total AOI area (sqkm): {formatted_area_sq}"
-        )
 
     def aoi_from_layer(self, layer):
         if not layer.isValid():
@@ -519,7 +528,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
                 log.debug("AOI set to layer")
 
                 self.zoom_to_aoi()
-                self.calculate_aoi_area()
+                self.show_aoi_area_size()
 
     def _toggle_selection_tools(self):
         active_layer = iface.activeLayer()
@@ -566,7 +575,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         log.debug("AOI set to canvas extent")
 
         self.zoom_to_aoi()
-        self.calculate_aoi_area()
+        self.show_aoi_area_size()
 
     @pyqtSlot()
     def aoi_from_active_layer_extent(self):
@@ -602,7 +611,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         log.debug("AOI set to active layer extent")
 
         self.zoom_to_aoi()
-        self.calculate_aoi_area()
+        self.show_aoi_area_size()
 
     @pyqtSlot()
     def aoi_from_full_extent(self):
@@ -634,7 +643,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         log.debug("AOI set to full data extent")
 
         self.zoom_to_aoi()
-        self.calculate_aoi_area()
+        self.show_aoi_area_size()
 
     @pyqtSlot()
     def aoi_from_box(self):
@@ -687,7 +696,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
 
             self._show_message("AOI set to drawn figure")
             self.zoom_to_aoi()
-            self.calculate_aoi_area()
+            self.show_aoi_area_size()
             if self._cur_maptool is not None:
                 # Restore previously used maptool
                 self._canvas.setMapTool(self._cur_maptool)
@@ -752,7 +761,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         self._aoi_box.setToGeometry(geom, QgsCoordinateReferenceSystem("EPSG:4326"))
         self.zoom_to_aoi()
 
-        self.calculate_aoi_area()
+        self.show_aoi_area_size()
 
     @pyqtSlot()
     def aoi_from_bound(self):
@@ -791,7 +800,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         self._aoi_box.setToGeometry(QgsGeometry.fromRect(bbox_canvas))
 
         self.zoom_to_aoi()
-        self.calculate_aoi_area()
+        self.show_aoi_area_size()
 
     def hide_aoi_if_matches_geom(self, geom):
         color = (
@@ -894,7 +903,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         self.leAOI.blockSignals(False)
 
         self.zoom_to_aoi()
-        self.calculate_aoi_area()
+        self.show_aoi_area_size()
 
 
 class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -459,37 +459,30 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
             self.aoi_from_layer(layer)
 
     def show_aoi_area_size(self):
-        """ Displays the aoi area size in square kilometers.
-        """
+        """Displays the aoi area size in square kilometers."""
 
         area_size_sqkm = self.calculate_aoi_area()
 
         formatted_area_sq = "{:,}".format(round(area_size_sqkm, 2))
 
-        self.laAOISize.setText(
-            f"Total AOI area (sqkm): {formatted_area_sq}"
-        )
+        self.laAOISize.setText(f"Total AOI area (sqkm): {formatted_area_sq}")
 
     def calculate_aoi_area(self):
-        """ Calculate the current aoi area in square kilometers """
+        """Calculate the current aoi area in square kilometers"""
 
         geometry = self.aoi_as_4326_geom()
         area = QgsDistanceArea()
         area.setSourceCrs(
-            QgsCoordinateReferenceSystem('EPSG:4326'),
-            QgsProject.instance().transformContext()
+            QgsCoordinateReferenceSystem("EPSG:4326"),
+            QgsProject.instance().transformContext(),
         )
-        area.setEllipsoid(
-            QgsProject.instance().ellipsoid()
-        )
+        area.setEllipsoid(QgsProject.instance().ellipsoid())
         geometry_area = area.measureArea(geometry)
         geometry_area_sq = area.convertAreaMeasurement(
-            geometry_area,
-            QgsUnitTypes.AreaSquareKilometers
+            geometry_area, QgsUnitTypes.AreaSquareKilometers
         )
 
         return round(geometry_area_sq, 2)
-
 
     def aoi_from_layer(self, layer):
         if not layer.isValid():
@@ -873,6 +866,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         json_txt = self.leAOI.text()
         if not json_txt:
             self.reset_aoi_box()
+            self.show_aoi_area_size()
             log.debug("No AOI defined, skipping validation")
             return
 

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -488,7 +488,7 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
             QgsUnitTypes.AreaSquareKilometers
         )
 
-        return geometry_area_sq
+        return round(geometry_area_sq, 2)
 
 
     def aoi_from_layer(self, layer):

--- a/planet_explorer/tests/test_filters.py
+++ b/planet_explorer/tests/test_filters.py
@@ -18,7 +18,7 @@ from planet_explorer.gui.pe_filters import PlanetAOIFilter
                 QgsPointXY(QgsPoint(10, 20)),
                 QgsPointXY(QgsPoint(20, 20)),
                 QgsPointXY(QgsPoint(20, 10)),
-                QgsPointXY(QgsPoint(10, 10))
+                QgsPointXY(QgsPoint(10, 10)),
             ],
             1239202.90,
             id="area_of_interest_with_small_size",
@@ -30,7 +30,7 @@ from planet_explorer.gui.pe_filters import PlanetAOIFilter
                 QgsPointXY(QgsPoint(10, 40)),
                 QgsPointXY(QgsPoint(40, 40)),
                 QgsPointXY(QgsPoint(40, 10)),
-                QgsPointXY(QgsPoint(10, 10))
+                QgsPointXY(QgsPoint(10, 10)),
             ],
             11152826.13,
             id="area_of_interest_with_medium_size",
@@ -42,7 +42,7 @@ from planet_explorer.gui.pe_filters import PlanetAOIFilter
                 QgsPointXY(QgsPoint(10, 60)),
                 QgsPointXY(QgsPoint(60, 60)),
                 QgsPointXY(QgsPoint(60, 10)),
-                QgsPointXY(QgsPoint(10, 10))
+                QgsPointXY(QgsPoint(10, 10)),
             ],
             30980072.58,
             id="area_of_interest_with_large_size",
@@ -54,7 +54,7 @@ from planet_explorer.gui.pe_filters import PlanetAOIFilter
                 QgsPointXY(QgsPoint(0, 0)),
                 QgsPointXY(QgsPoint(0, 0)),
                 QgsPointXY(QgsPoint(0, 0)),
-                QgsPointXY(QgsPoint(0, 0))
+                QgsPointXY(QgsPoint(0, 0)),
             ],
             0.0,
             id="area_of_interest_with_zero_size",
@@ -62,8 +62,7 @@ from planet_explorer.gui.pe_filters import PlanetAOIFilter
     ],
 )
 def test_aoi_area_size_calculation(name, polygon, expected_size):
-    """Tests the filter for calculating the aoi size in square kilometers
-    """
+    """Tests the filter for calculating the aoi size in square kilometers"""
     aoi_filter = PlanetAOIFilter()
     aoi_box = QgsRubberBand(iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)
 

--- a/planet_explorer/tests/test_filters.py
+++ b/planet_explorer/tests/test_filters.py
@@ -1,24 +1,76 @@
 import pytest
 
-from qgis.core import QgsGeometry, QgsPoint, QgsRubberBand, QgsWkbTypes
+from qgis.core import QgsGeometry, QgsPoint, QgsPointXY, QgsWkbTypes
+from qgis.gui import QgsRubberBand
 from qgis.utils import iface
 from qgis.PyQt import QtCore
 
 from planet_explorer.gui.pe_filters import PlanetAOIFilter
 
 
-def test_aoi_area_size_calculation(
-    qtbot,
-):
-    """
+@pytest.mark.parametrize(
+    "name, polygon, expected_size",
+    [
+        pytest.param(
+            "small_polygon",
+            [
+                QgsPointXY(QgsPoint(10, 10)),
+                QgsPointXY(QgsPoint(10, 20)),
+                QgsPointXY(QgsPoint(20, 20)),
+                QgsPointXY(QgsPoint(20, 10)),
+                QgsPointXY(QgsPoint(10, 10))
+            ],
+            1239202.90,
+            id="area_of_interest_with_small_size",
+        ),
+        pytest.param(
+            "mid_polygon",
+            [
+                QgsPointXY(QgsPoint(10, 10)),
+                QgsPointXY(QgsPoint(10, 40)),
+                QgsPointXY(QgsPoint(40, 40)),
+                QgsPointXY(QgsPoint(40, 10)),
+                QgsPointXY(QgsPoint(10, 10))
+            ],
+            11152826.13,
+            id="area_of_interest_with_medium_size",
+        ),
+        pytest.param(
+            "large_polygon",
+            [
+                QgsPointXY(QgsPoint(10, 10)),
+                QgsPointXY(QgsPoint(10, 60)),
+                QgsPointXY(QgsPoint(60, 60)),
+                QgsPointXY(QgsPoint(60, 10)),
+                QgsPointXY(QgsPoint(10, 10))
+            ],
+            30980072.58,
+            id="area_of_interest_with_large_size",
+        ),
+        pytest.param(
+            "small_polygon",
+            [
+                QgsPointXY(QgsPoint(0, 0)),
+                QgsPointXY(QgsPoint(0, 0)),
+                QgsPointXY(QgsPoint(0, 0)),
+                QgsPointXY(QgsPoint(0, 0)),
+                QgsPointXY(QgsPoint(0, 0))
+            ],
+            0.0,
+            id="area_of_interest_with_zero_size",
+        ),
+    ],
+)
+def test_aoi_area_size_calculation(name, polygon, expected_size):
+    """Tests the filter for calculating the aoi size in square kilometers
     """
     aoi_filter = PlanetAOIFilter()
     aoi_box = QgsRubberBand(iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)
-    points = [QgsPoint(60, 60), QgsPoint(60, 80), QgsPoint(80, 80), QgsPoint(80, 60), QgsPoint(60, 60)]
-    geometry = QgsGeometry.fromPolygon([points])
-    aoi_box.setGeometry(geometry)
+
+    geometry = QgsGeometry.fromPolygonXY([polygon])
+    aoi_box.setToGeometry(geometry)
 
     aoi_filter._aoi_box = aoi_box
     size = aoi_filter.calculate_aoi_area()
 
-    assert size == 1000
+    assert size == expected_size

--- a/planet_explorer/tests/test_filters.py
+++ b/planet_explorer/tests/test_filters.py
@@ -3,7 +3,6 @@ import pytest
 from qgis.core import QgsGeometry, QgsPoint, QgsPointXY, QgsWkbTypes
 from qgis.gui import QgsRubberBand
 from qgis.utils import iface
-from qgis.PyQt import QtCore
 
 from planet_explorer.gui.pe_filters import PlanetAOIFilter
 

--- a/planet_explorer/tests/test_filters.py
+++ b/planet_explorer/tests/test_filters.py
@@ -1,0 +1,24 @@
+import pytest
+
+from qgis.core import QgsGeometry, QgsPoint, QgsRubberBand, QgsWkbTypes
+from qgis.utils import iface
+from qgis.PyQt import QtCore
+
+from planet_explorer.gui.pe_filters import PlanetAOIFilter
+
+
+def test_aoi_area_size_calculation(
+    qtbot,
+):
+    """
+    """
+    aoi_filter = PlanetAOIFilter()
+    aoi_box = QgsRubberBand(iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)
+    points = [QgsPoint(60, 60), QgsPoint(60, 80), QgsPoint(80, 80), QgsPoint(80, 60), QgsPoint(60, 60)]
+    geometry = QgsGeometry.fromPolygon([points])
+    aoi_box.setGeometry(geometry)
+
+    aoi_filter._aoi_box = aoi_box
+    size = aoi_filter.calculate_aoi_area()
+
+    assert size == 1000

--- a/planet_explorer/tests/test_filters.py
+++ b/planet_explorer/tests/test_filters.py
@@ -1,7 +1,7 @@
 import pytest
 
 from qgis.core import QgsGeometry, QgsPoint, QgsPointXY, QgsWkbTypes
-from qgis.gui import QgsRubberBand
+from qgis.gui import QgsRubberBand, QgsMapCanvas
 from qgis.utils import iface
 
 from planet_explorer.gui.pe_filters import PlanetAOIFilter
@@ -63,7 +63,8 @@ from planet_explorer.gui.pe_filters import PlanetAOIFilter
 def test_aoi_area_size_calculation(name, polygon, expected_size):
     """Tests the filter for calculating the aoi size in square kilometers"""
     aoi_filter = PlanetAOIFilter()
-    aoi_box = QgsRubberBand(iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)
+    canvas = iface.mapCanvas() if iface else QgsMapCanvas()
+    aoi_box = QgsRubberBand(canvas, QgsWkbTypes.PolygonGeometry)
 
     geometry = QgsGeometry.fromPolygonXY([polygon])
     aoi_box.setToGeometry(geometry)

--- a/planet_explorer/ui/pe_aoi_filter_base.ui
+++ b/planet_explorer/ui/pe_aoi_filter_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>612</width>
-    <height>85</height>
+    <width>613</width>
+    <height>148</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -267,6 +267,26 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="laAOISize">
+        <property name="text">
+         <string>Total AOI area (sqkm):</string>
+        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Supersedes https://github.com/planetlabs/qgis-planet-plugin/pull/61
Opened this PR based on the discussion from https://github.com/planetlabs/qgis-planet-plugin/issues/62#issuecomment-1305836036

Adds text widget in the area of interest widget that shows the current area of interest size in square kilometers.

Includes new tests for checking the function responsible for the size calcuations.


Screenshot
![updated_shot_for_aoi](https://user-images.githubusercontent.com/2663775/201907733-3dc4a192-478e-48de-a4c4-174b54d5b1e4.gif)
