### PR TITLE
Dashboard url change for the autofill tasking coordinates

### DIFF
--- a/planet_explorer/gui/pe_tasking_dockwidget.py
+++ b/planet_explorer/gui/pe_tasking_dockwidget.py
@@ -135,7 +135,9 @@ class WarningDialog(QDialog):
     def _link_clicked(self, url):
         if url.toString() == "dashboard":
             analytics_track(SKYSAT_TASK_CREATED)
-            url = f"https://www.planet.com/tasking/orders/new/?geometry={self.pt.asWkt()}"
+            url = (
+                f"https://www.planet.com/tasking/orders/new/?geometry={self.pt.asWkt()}"
+            )
             open_link_with_browser(url)
             self.close()
         else:

--- a/planet_explorer/gui/pe_tasking_dockwidget.py
+++ b/planet_explorer/gui/pe_tasking_dockwidget.py
@@ -135,7 +135,7 @@ class WarningDialog(QDialog):
     def _link_clicked(self, url):
         if url.toString() == "dashboard":
             analytics_track(SKYSAT_TASK_CREATED)
-            url = f"https://www.planet.com/tasking/orders/new/#/geometry/{self.pt.asWkt()}"
+            url = f"https://www.planet.com/tasking/orders/new/?geometry={self.pt.asWkt()}"
             open_link_with_browser(url)
             self.close()
         else:


### PR DESCRIPTION
Updates the URL used for loading the tasking dashboard using a new format.

Old format
https://www.planet.com/tasking/orders/new/#/geometry/POINT(-50.71459969007946%20-15.71923164396603)

New format
https://www.planet.com/tasking/orders/new/?geometry=POINT(-50.71459969007946%20-15.71923164396603) 

Screenshot of the feature using the new URL format
![fix_for_dashboard_url](https://user-images.githubusercontent.com/2663775/200784461-eabb75a4-9f2b-41f2-a926-6334f6bed87f.gif)

