### PR TITLE
Fix for login error

### DIFF
--- a/planet_explorer/gui/pe_explorer_dockwidget.py
+++ b/planet_explorer/gui/pe_explorer_dockwidget.py
@@ -289,7 +289,7 @@ class PlanetExplorerDockWidget(BASE, WIDGET):
             self._auth_man.authSetting(AUTH_CREDS_KEY, defaultValue="", decrypt=True)
             or ""
         )
-        creds = auth_creds_str.split(AUTH_SEP)
+        creds = auth_creds_str.split(AUTH_SEP) if auth_creds_str is not None else []
         return {
             "user": creds[0] if len(creds) > 0 else None,
             "password": creds[1] if len(creds) > 1 else None,


### PR DESCRIPTION
When trying to login a user it possible for now the credentials reading to cause an AttributeError, see below screenshot.

![image](https://user-images.githubusercontent.com/2663775/202131025-32bb75b9-60a5-4d07-8a58-25e48996cafa.png)

These changes add a check if credential string retrieved from QGIS authentication database contains values unless we should default to an empty list of credentials.