### PR TITLE
Update on Qt imports

### DIFF
--- a/planet_explorer/gui/pe_basemap_layer_widget.py
+++ b/planet_explorer/gui/pe_basemap_layer_widget.py
@@ -18,9 +18,9 @@ import json
 import os
 from urllib.parse import quote
 
-from PyQt5.QtCore import QByteArray, QRectF, QSize, Qt, pyqtSignal
-from PyQt5.QtGui import QBrush, QColor, QImage, QPainter, QPixmap
-from PyQt5.QtWidgets import (
+from qgis.PyQt.QtCore import QByteArray, QRectF, QSize, Qt, pyqtSignal
+from qgis.PyQt.QtGui import QBrush, QColor, QImage, QPainter, QPixmap
+from qgis.PyQt.QtWidgets import (
     QComboBox,
     QFrame,
     QGridLayout,

--- a/planet_explorer/gui/pe_basemaps_list_widget.py
+++ b/planet_explorer/gui/pe_basemaps_list_widget.py
@@ -24,9 +24,9 @@ __copyright__ = "(C) 2019 Planet Inc, https://planet.com"
 __revision__ = "$Format:%H$"
 
 
-from PyQt5.QtCore import QSize, Qt, pyqtSignal
-from PyQt5.QtGui import QIcon, QImage, QPalette, QPixmap
-from PyQt5.QtWidgets import (
+from qgis.PyQt.QtCore import QSize, Qt, pyqtSignal
+from qgis.PyQt.QtGui import QIcon, QImage, QPalette, QPixmap
+from qgis.PyQt.QtWidgets import (
     QAction,
     QCheckBox,
     QHBoxLayout,

--- a/planet_explorer/gui/pe_basemaps_widget.py
+++ b/planet_explorer/gui/pe_basemaps_widget.py
@@ -28,11 +28,11 @@ import os
 
 from planet.api.exceptions import InvalidAPIKey
 from planet.api.models import MosaicQuads, Mosaics
-from PyQt5 import QtCore
-from PyQt5.QtCore import QObject, QThread, QUrl, pyqtSignal
-from PyQt5.QtGui import QImage, QPixmap
-from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest
-from PyQt5.QtWidgets import QApplication, QMessageBox, QVBoxLayout
+from qgis.PyQt import QtCore
+from qgis.PyQt.QtCore import QObject, QThread, QUrl, pyqtSignal
+from qgis.PyQt.QtGui import QImage, QPixmap
+from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkRequest
+from qgis.PyQt.QtWidgets import QApplication, QMessageBox, QVBoxLayout
 from qgis.core import Qgis, QgsDistanceArea, QgsGeometry, QgsRectangle, QgsUnitTypes
 from qgis.PyQt import uic
 

--- a/planet_explorer/gui/pe_planet_inspector_dockwidget.py
+++ b/planet_explorer/gui/pe_planet_inspector_dockwidget.py
@@ -29,7 +29,7 @@ import iso8601
 import mercantile
 from planet.api.filters import build_search_request, string_filter
 from planet.api.models import Mosaics
-from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest
+from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkRequest
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/planet_explorer/gui/pe_quads_treewidget.py
+++ b/planet_explorer/gui/pe_quads_treewidget.py
@@ -23,10 +23,10 @@ __revision__ = "$Format:%H$"
 
 from collections import defaultdict
 
-from PyQt5 import QtCore
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import (
+from qgis.PyQt import QtCore
+from qgis.PyQt.QtCore import Qt, pyqtSignal
+from qgis.PyQt.QtGui import QPixmap
+from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QFrame,
     QHBoxLayout,

--- a/planet_explorer/gui/pe_thumbnails.py
+++ b/planet_explorer/gui/pe_thumbnails.py
@@ -24,7 +24,7 @@ __revision__ = "$Format:%H$"
 
 from collections import defaultdict
 
-from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
+from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 from qgis.core import QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject
 from qgis.PyQt.QtCore import Qt, QUrl
 from qgis.PyQt.QtGui import QImage, QPainter, QPixmap

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -32,7 +32,7 @@ from typing import (
     List,
 )
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QSettings
+from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QObject, QSettings
 from qgis.core import QgsAuthMethodConfig, QgsApplication, QgsMessageLog, Qgis
 
 

--- a/planet_explorer/tests/test_orders.py
+++ b/planet_explorer/tests/test_orders.py
@@ -1,6 +1,6 @@
 import pytest
 
-from PyQt5.QtWidgets import QPushButton
+from qgis.PyQt.QtWidgets import QPushButton
 from qgis.PyQt import QtCore
 from planet_explorer.gui.pe_orders import PlanetOrdersDialog
 from planet_explorer.gui.pe_orders_monitor_dockwidget import OrderWrapper

--- a/planet_explorer/tests/test_tasking.py
+++ b/planet_explorer/tests/test_tasking.py
@@ -3,7 +3,7 @@ import pytest
 from planet_explorer.tests.utils import qgis_debug_wait
 from qgis.PyQt import QtCore
 from planet_explorer.gui.pe_tasking_dockwidget import WarningDialog
-from PyQt5.QtWidgets import QTextBrowser
+from qgis.PyQt.QtWidgets import QTextBrowser
 
 pytestmark = [pytest.mark.qgis_show_map(add_basemap=False, timeout=1)]
 


### PR DESCRIPTION
Changes on all Qt related imports, the plugin should use the QGIS Qt API instead of the standalone library, this helps to avoid Qt classes imports errors and it is the recommended practice  by QGIS development guidelines.