### PR TITLE
Dev pre commit fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,12 @@ repos:
       - id: check-json
         exclude: ^(planet_explorer/planet_api/request-result-samples/)
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 5.0.4
     hooks:
       - id: flake8
         language_version: python3
+        args: ['--extend-ignore=E203, E501']


### PR DESCRIPTION
Cause of the issue: https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated, 'Why are Flake8's E203 and W503 violated?'. E203 is the error with whitespace characters before ':', black adds a whitespace before ':', causing a conflict with flake8. This removes this change made by black. E501 is line length, because the line length of flake8 and black differs. Both these changes are recommended on the black page provided above so that flake8 and black can have no clashes. https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html

Also updated flake8 and black to make use of the latest versions.

@john-dupuy These minor changes is to fix the clashes between flake8 and black. Basically this issue was noted with the add to map button PR. So what happens is that black adds a space before a ':' character, which causes flake8 to break. These changes is suggested by black (see the PR description for more details) to solve the problem and allow black and flake8 together.