### PR TITLE
Dev basemaps fix

### DIFF
--- a/planet_explorer/gui/pe_basemaps_widget.py
+++ b/planet_explorer/gui/pe_basemaps_widget.py
@@ -192,6 +192,7 @@ class BasemapsWidget(BASE, WIDGET):
 
     def reset(self):
         self._initialized = False
+        self._series = None
 
     def batch_select_mosaics_clicked(self, url="all"):
         checked = url == "all"

--- a/planet_explorer/gui/pe_explorer_dockwidget.py
+++ b/planet_explorer/gui/pe_explorer_dockwidget.py
@@ -228,6 +228,7 @@ class PlanetExplorerDockWidget(BASE, WIDGET):
         else:
             self._set_credential_fields()
             self.switch_to_login_panel()
+            self.basemaps_widget.reset()
 
     @pyqtSlot()
     def switch_to_login_panel(self):


### PR DESCRIPTION
A user, whom should have access to basemaps, would sometimes not have basemaps available:
![image](https://user-images.githubusercontent.com/79740955/209947431-e097bb6d-b877-4cce-b2ae-54854792d49e.png)
The only workaround were to restart qgis and login in again. It was also found, that if a user logs into the plugin after another user whom had access to basemaps, logged out, the newly logged user will have access to basemaps even when they shouldn't.

The cause was pinned down to the basemaps widget only fetching basemaps available to the user on the first login. So if a user logged out, and another user logged in, the previous user's basemaps were still in use. This also explains why restarting qgis solved the problem.

The problem has now been resolved and the basemaps list will be reset if a new user logs and then fetched again:
![image](https://user-images.githubusercontent.com/79740955/209947449-80fe0599-467e-49d8-936d-bc25c5d3de7d.png)
