### PR TITLE
Upload vector file extent

### DIFF
--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -488,13 +488,17 @@ class PlanetAOIFilter(AOI_FILTER_BASE, AOI_FILTER_WIDGET, PlanetFilterMixin):
         if not layer.isValid():
             self._show_message("Invalid layer", level=Qgis.Warning, duration=10)
         else:
-            feature = next(layer.getFeatures(), None)
-            if feature is None:
+            feature_count = layer.featureCount()
+            if feature_count == 0:
                 self._show_message(
                     "Layer contains no features", level=Qgis.Warning, duration=10
                 )
             else:
-                geom = feature.geometry()
+                # The layer bounding box will be used to include all features
+                layer.selectAll()
+                bounding_box = layer.boundingBoxOfSelected()
+                bb_polygon = bounding_box.asWktPolygon()
+                geom = QgsGeometry().fromWkt(bb_polygon)
 
                 transform = QgsCoordinateTransform(
                     layer.crs(),


### PR DESCRIPTION
When using the Upload option when provided an extent for the search filter, only the first features in the vector layer considered:
![image](https://user-images.githubusercontent.com/79740955/209947832-5b5de643-9806-4dbf-8c92-56b1631df4cd.png)

The upload function will now consider all of the features and make use of a bounding box to create the extent. This is the same manner as how the selection option works when creating an extent.
![image](https://user-images.githubusercontent.com/79740955/209947936-b86876d8-8925-4c2d-823e-724464b12d7a.png)
