### PR TITLE
Run tests only on major releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        qgis_version: [ release-3_10, release-3_16, release-3_24, release-3_26, latest ]
+        qgis_version: [ release-3_10, release-3_16, release-3_24, release-3_26, release-3_28 ]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
       # cf https://docs.qgis.org/3.16/en/docs/user_manual/introduction/qgis_configuration.html#running-qgis-with-advanced-settings

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        qgis_version: [release-3_10, release-3_16, release-3_24, release-3_26, latest]
+        qgis_version: [release-3_10, release-3_16, release-3_24, release-3_26, release-3_28]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:


### PR DESCRIPTION
There's a bug that's impacting the plugin install test:
```
FAIL: Plugin install, load, unload, and uninstall failed with the following:
Traceback (most recent call last):
  File "<string>", line 73, in <module>
  File "/usr/share/qgis/python/pyplugin_installer/installer.py", line 581, in installFromZipFile
    QgsSettings.createPluginTreeNode("_plugin_manager").childSetting("last-zip-directory").setValue(QFileInfo(filePath).absoluteDir().absolutePath())
AttributeError: 'NoneType' object has no attribute 'setValue'
```

I believe it may have come from https://github.com/qgis/QGIS/pull/51614? Regardless, we should only run tests and install against the stable releases. 