### PR TITLE
Preparation for v2.3.0 pre release

### DIFF
--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -22,8 +22,14 @@ repository=https://github.com/planetlabs/qgis-planet-plugin
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
-  v2.3.0 (2023-02-01)
-  * Pre-release
+  v2.3.0 (2023-02-09)
+  * Better multi-polygon search handling. Users can now search in individual polygons in a multi-polygon or by selecting a bounding box around the multi-polygon extent.
+  * New "Add to Map" button in the Orders Panel that when selected will automatically render a true color visualization of PlanetScope or SkySat imagery in the QGIS map.
+  * Added STAC metadata as an option during Order Checkout so customers can download their images with STAC metadata.
+  * Fixed some the metadata fields in our imagery footprints so that they now have the correct data format. Previously, all fields in the footprint's attribute table were strings.
+  * Updated a few links in the Add-In to our Developer Trial, Planet University, Planet Community and ToS.
+  * Customers can now see a SQKM size estimate when they draw an AOI to search for imagery or  Basemap quads for download.
+  * The Basemap series cadence filter is now ordered correctly.
   v2.2.0 (2022-03-01)
   * This update adds a new PlanetScope imagery type (PSScene) that includes new 8-band PlanetScope imagery that is radiometrically aligned with Sentinel-2
   * Users can also find a new option to "harmonize" their PlanetScope Surface Reflectance orders at checkout to improve the radiometric consistency across different PlanetScope sensors

--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -23,6 +23,7 @@ hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
   v2.3.0 (2023-02-09)
+  * Fixed the auto-fill coordinates feature for setting a point collect location in QGIS and auto-populating those coordinates to our tasking dashboard.
   * Better multi-polygon search handling. Users can now search in individual polygons in a multi-polygon or by selecting a bounding box around the multi-polygon extent.
   * New "Add to Map" button in the Orders Panel that when selected will automatically render a true color visualization of PlanetScope or SkySat imagery in the QGIS map.
   * Added STAC metadata as an option during Order Checkout so customers can download their images with STAC metadata.

--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -22,6 +22,8 @@ repository=https://github.com/planetlabs/qgis-planet-plugin
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
+  v2.3.0 (2023-02-01)
+  * Pre-release
   v2.2.0 (2022-03-01)
   * This update adds a new PlanetScope imagery type (PSScene) that includes new 8-band PlanetScope imagery that is radiometrically aligned with Sentinel-2
   * Users can also find a new option to "harmonize" their PlanetScope Surface Reflectance orders at checkout to improve the radiometric consistency across different PlanetScope sensors


### PR DESCRIPTION
Updates the metadata.txt with the new pre-release details

Highlight of the changes that will be included in the new release
- Fixed the auto-fill coordinates feature for setting a point collect location in QGIS and auto-populating those coordinates to our tasking dashboard - https://github.com/planetlabs/qgis-planet-plugin/pull/70
- Added STAC metadata as a checkout option so that users can download their data with STAC metadata - https://github.com/planetlabs/qgis-planet-plugin/pull/67
-  New "add to map" button in the Orders Panel, that when used will automatically order our spectral bands to the right RGB display for PlanetScope and SkySat - https://github.com/planetlabs/qgis-planet-plugin/pull/103
-  Added a sqkm size estimate when drawing an area to download Basemap Quads - https://github.com/planetlabs/qgis-planet-plugin/pull/69
- Customers can now search within their multi-polygons -https://github.com/planetlabs/qgis-planet-plugin/pull/94
- Better bug handling and tracking with Sentry -https://github.com/planetlabs/qgis-planet-plugin/pull/75 and https://github.com/planetlabs/qgis-planet-plugin/pull/80
- Basemaps cadences are now listed in the correct order -https://github.com/planetlabs/qgis-planet-plugin/pull/92
- Fix for area coverage filtering - https://github.com/planetlabs/qgis-planet-plugin/pull/119
- Fixed some the metadata fields in the imagery footprints -https://github.com/planetlabs/qgis-planet-plugin/pull/98