### PR TITLE
Fix area coverage filtering bug

### DIFF
--- a/planet_explorer/gui/pe_dailyimages_search_results_widget.py
+++ b/planet_explorer/gui/pe_dailyimages_search_results_widget.py
@@ -312,7 +312,7 @@ class DailyImagesSearchResultsWidget(RESULTS_BASE, RESULTS_WIDGET):
         if filt:
             minvalue = filt["config"].get("gte", 0)
             maxvalue = filt["config"].get("lte", 100)
-            return area_coverage > minvalue and area_coverage < maxvalue
+            return area_coverage >= minvalue and area_coverage <= maxvalue
         return True
 
     def _find_item_for_date(self, image):

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -286,36 +286,28 @@ def create_preview_vector_layer(image):
         QgsField("sort_order", QVariant.String),
     ]
 
-    prop_dates = [
-        'acquired',
-        'published',
-        'updated'
-    ]
-    prop_int = [
-        'anomalous_pixels'
-    ]
+    prop_dates = ["acquired", "published", "updated"]
+    prop_int = ["anomalous_pixels"]
     prop_double = [
-        'clear_confidence_percent',
-        'clear_percent',
-        'cloud_cover',
-        'cloud_percent',
-        'ground_control_ratio',  # Only SkySat
-        'gsd',
-        'heavy_haze_percent',
-        'light_haze_percent',
-        'pixel_resolution',
-        'satellite_azimuth',
-        'shadow_percent',
-        'snow_ice_percent',
-        'sun_azimuth',
-        'sun_elevation',
-        'view_angle',
-        'visible_confidence_percent',
-        'visible_percent'
+        "clear_confidence_percent",
+        "clear_percent",
+        "cloud_cover",
+        "cloud_percent",
+        "ground_control_ratio",  # Only SkySat
+        "gsd",
+        "heavy_haze_percent",
+        "light_haze_percent",
+        "pixel_resolution",
+        "satellite_azimuth",
+        "shadow_percent",
+        "snow_ice_percent",
+        "sun_azimuth",
+        "sun_elevation",
+        "view_angle",
+        "visible_confidence_percent",
+        "visible_percent",
     ]
-    prop_boolean = [
-        'ground_control'  # Only PlanetScope
-    ]
+    prop_boolean = ["ground_control"]  # Only PlanetScope
 
     for prop in image["properties"]:
         # Determines the field types

--- a/planet_explorer/tests/test_daily_imagery.py
+++ b/planet_explorer/tests/test_daily_imagery.py
@@ -730,7 +730,9 @@ def test_aoi_bb_from_layer(layer_dir, expected_coordinates):
         ),
     ],
 )
-def test_aoi_from_multiple_polygons(qtbot, pe_qgis_iface, layer_dir, expected_coordinates, perform_selection):
+def test_aoi_from_multiple_polygons(
+    qtbot, pe_qgis_iface, layer_dir, expected_coordinates, perform_selection
+):
     """Tests the filter for the AOI read from no selection and a
     selection on a layer loaded in QGIS. AOI calculated from each polygon.
     """
@@ -794,7 +796,9 @@ def test_aoi_from_multiple_polygons(qtbot, pe_qgis_iface, layer_dir, expected_co
         ),
     ],
 )
-def test_bb_aoi_from_multiple_polygons(qtbot, pe_qgis_iface, layer_dir, expected_coordinates):
+def test_bb_aoi_from_multiple_polygons(
+    qtbot, pe_qgis_iface, layer_dir, expected_coordinates
+):
     """Tests the filter for the AOI read from on the bounding box of a layer
     loaded in QGIS. AOI calculated using a bounding box covering all polygons.
     """


### PR DESCRIPTION
The area coverage filtering in the plugin doesn't use the correct comparison when filtering out the found result images.
This PR updates the area coverage value comparison with minimum and maximum values submitted in the search request. 

Note: One of the unexpected operations is that the area coverage filtering is done post search see https://github.com/planetlabs/qgis-planet-plugin/blob/9217a94737b0e0d063151ffdde2f819c5216921d/planet_explorer/gui/pe_dailyimages_search_results_widget.py#L264, it would have been nice for this kind of filtering to be done in the Planet API and the returned resultset to already be filtered.


Screenshot of the current behaviour
![bug_area_coverage_filtering](https://user-images.githubusercontent.com/2663775/217625964-ed458dcb-8be0-4d7f-86b7-2f5369327b51.gif)

Screenshot of the fixed behaviour
![fixed_area_coverage_filter](https://user-images.githubusercontent.com/2663775/217626031-43b850c2-6c4e-43fd-8aae-cc609a8963a1.gif)

