### PR TITLE
Fixed an issue with the saved search loader dialog

### DIFF
--- a/planet_explorer/gui/pe_dailyimages_widget.py
+++ b/planet_explorer/gui/pe_dailyimages_widget.py
@@ -119,7 +119,7 @@ class DailyImagesWidget(BASE, WIDGET):
         self._default_filter_values = build_search_request(self._filters, self._sources)
 
     def open_saved_searches(self, dlg=None):
-        dlg = dlg if dlg else OpenSavedSearchDialog()
+        dlg = dlg if isinstance(dlg, OpenSavedSearchDialog) else OpenSavedSearchDialog()
         if dlg.exec() == OpenSavedSearchDialog.Accepted:
             saved_search_request = dlg.saved_search
             request = {}


### PR DESCRIPTION
An error occurred when clicking on the "load a saved search" link. This has now been fixed, a user can op the dialog, and load saved searches.

![image](https://user-images.githubusercontent.com/79740955/217900472-6ff6340a-28c4-4961-b611-387154ce0567.png)
