### PR TITLE
Handle bad request errors

### DIFF
--- a/planet_explorer/gui/pe_dailyimages_search_results_widget.py
+++ b/planet_explorer/gui/pe_dailyimages_search_results_widget.py
@@ -26,10 +26,12 @@ import os
 
 import iso8601
 from qgis.core import (
+    Qgis,
     QgsApplication,
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
     QgsGeometry,
+    QgsMessageLog,
     QgsProject,
     QgsRectangle,
     QgsWkbTypes,
@@ -48,6 +50,8 @@ from qgis.PyQt.QtWidgets import (
     QTreeWidgetItemIterator,
 )
 
+from planet.api.exceptions import APIException, BadQuery
+
 from ..gui.pe_results_configuration_dialog import (
     PlanetNodeMetadata,
     ResultsConfigurationDialog,
@@ -61,6 +65,7 @@ from ..pe_analytics import (
 
 from ..pe_utils import (
     PLANET_COLOR,
+    QGIS_LOG_SECTION_NAME,
     SEARCH_AOI_COLOR,
     area_coverage_for_image,
     create_preview_group,
@@ -229,19 +234,39 @@ class DailyImagesSearchResultsWidget(RESULTS_BASE, RESULTS_WIDGET):
         self.tree.clear()
         stats_request = {"interval": "year"}
         stats_request.update(self._request)
-        resp = self._p_client.stats(stats_request).get()
-        self._total_count = sum([b["count"] for b in resp["buckets"]])
-        if self._total_count:
-            response = self._p_client.quick_search(
-                self._request,
-                page_size=TOP_ITEMS_BATCH,
-                sort=" ".join(self.sort_order()),
+
+        try:
+            resp = self._p_client.stats(stats_request).get()
+            self._total_count = sum([b["count"] for b in resp["buckets"]])
+            if self._total_count:
+                response = self._p_client.quick_search(
+                    self._request,
+                    page_size=TOP_ITEMS_BATCH,
+                    sort=" ".join(self.sort_order()),
+                )
+                self._response_iterator = response.iter()
+                self.load_more()
+                self._set_widgets_visibility(True)
+            else:
+                self._set_widgets_visibility(False)
+
+        except BadQuery as bq:
+            QgsMessageLog.logMessage(
+                f"Exception during search, "
+                f"the search parameters are invalid."
+                f"Error details {bq}.",
+                QGIS_LOG_SECTION_NAME,
+                Qgis.Critical,
             )
-            self._response_iterator = response.iter()
-            self.load_more()
-            self._set_widgets_visibility(True)
-        else:
-            self._set_widgets_visibility(False)
+
+            iface.messageBar().pushMessage(
+                "Planet Explorer",
+                "Encountered a problem during search, "
+                "Make sure search parameters are valid. "
+                "See logs for details",
+                level=Qgis.Critical,
+                duration=10,
+            )
 
     @waitcursor
     def load_more(self):

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -286,36 +286,28 @@ def create_preview_vector_layer(image):
         QgsField("sort_order", QVariant.String),
     ]
 
-    prop_dates = [
-        'acquired',
-        'published',
-        'updated'
-    ]
-    prop_int = [
-        'anomalous_pixels'
-    ]
+    prop_dates = ["acquired", "published", "updated"]
+    prop_int = ["anomalous_pixels"]
     prop_double = [
-        'clear_confidence_percent',
-        'clear_percent',
-        'cloud_cover',
-        'cloud_percent',
-        'ground_control_ratio',  # Only SkySat
-        'gsd',
-        'heavy_haze_percent',
-        'light_haze_percent',
-        'pixel_resolution',
-        'satellite_azimuth',
-        'shadow_percent',
-        'snow_ice_percent',
-        'sun_azimuth',
-        'sun_elevation',
-        'view_angle',
-        'visible_confidence_percent',
-        'visible_percent'
+        "clear_confidence_percent",
+        "clear_percent",
+        "cloud_cover",
+        "cloud_percent",
+        "ground_control_ratio",  # Only SkySat
+        "gsd",
+        "heavy_haze_percent",
+        "light_haze_percent",
+        "pixel_resolution",
+        "satellite_azimuth",
+        "shadow_percent",
+        "snow_ice_percent",
+        "sun_azimuth",
+        "sun_elevation",
+        "view_angle",
+        "visible_confidence_percent",
+        "visible_percent",
     ]
-    prop_boolean = [
-        'ground_control'  # Only PlanetScope
-    ]
+    prop_boolean = ["ground_control"]  # Only PlanetScope
 
     for prop in image["properties"]:
         # Determines the field types

--- a/planet_explorer/tests/test_daily_imagery.py
+++ b/planet_explorer/tests/test_daily_imagery.py
@@ -730,7 +730,9 @@ def test_aoi_bb_from_layer(layer_dir, expected_coordinates):
         ),
     ],
 )
-def test_aoi_from_multiple_polygons(qtbot, pe_qgis_iface, layer_dir, expected_coordinates, perform_selection):
+def test_aoi_from_multiple_polygons(
+    qtbot, pe_qgis_iface, layer_dir, expected_coordinates, perform_selection
+):
     """Tests the filter for the AOI read from no selection and a
     selection on a layer loaded in QGIS. AOI calculated from each polygon.
     """
@@ -794,7 +796,9 @@ def test_aoi_from_multiple_polygons(qtbot, pe_qgis_iface, layer_dir, expected_co
         ),
     ],
 )
-def test_bb_aoi_from_multiple_polygons(qtbot, pe_qgis_iface, layer_dir, expected_coordinates):
+def test_bb_aoi_from_multiple_polygons(
+    qtbot, pe_qgis_iface, layer_dir, expected_coordinates
+):
     """Tests the filter for the AOI read from on the bounding box of a layer
     loaded in QGIS. AOI calculated using a bounding box covering all polygons.
     """


### PR DESCRIPTION
Adds check to handle bad queries errors caused by invalid input request to the Planet API.
This includes showing a message bar to the user indicating that they have provided invalid search input/parameters.

**Screenshot current behaviour**
![bad_query_planet_error](https://user-images.githubusercontent.com/2663775/218175285-7f73a28d-b78a-487b-846d-329958c42c1e.gif)


**Screenshot fixed behaviour**
![handled_error_during_search](https://user-images.githubusercontent.com/2663775/218175535-d30170e1-b631-4581-85e6-16336b66e9ce.gif)
