### PR TITLE
Require a version of planet compatible with 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
-requests-futures
-planet
+requests-futures<1.0
+planet~=1.4
 iso8601
 mercantile
 analytics-python


### PR DESCRIPTION
2.0.0 is coming out soon and is not compatible with this plugin.

The planet project found that requests-futures >= 1.0 is not compatible with the planet package.