### PR TITLE
Publishing stage filtering

### DIFF
--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1303,7 +1303,11 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
 
         # Publishing stage
         publish_types = []
-        for chk in [self.cb_publish_preview_3, self.cb_publish_standard_3, self.cb_publish_finalized_3]:
+        for chk in [
+            self.cb_publish_preview_3,
+            self.cb_publish_standard_3,
+            self.cb_publish_finalized_3,
+        ]:
             # preview, standard and finalized
             if chk.isChecked():
                 publish_types.append(chk.property("api-publish"))

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1301,6 +1301,18 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
                     "No valid ID present", level=Qgis.Warning, duration=10
                 )
 
+        # Publishing stage
+        publish_types = []
+        for chk in [self.cb_publish_preview_3, self.cb_publish_standard_3, self.cb_publish_finalized_3]:
+            # preview, standard and finalized
+            if chk.isChecked():
+                publish_types.append(chk.property("api-publish"))
+        if publish_types:
+            # Adds the Publishing stage to the filters if any were active
+            # Metadata name is "publishing_stage"
+            publish_filters = string_filter("publishing_stage", *publish_types)
+            populated_filters.append(publish_filters)
+
         instruments = []
         for chk in [self.chkPs2, self.chkPs2Sd, self.chkPsbSd]:
             if chk.isChecked():

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1133,7 +1133,6 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
 
         self.itemTypeCheckBoxes = [
             self.chkPlanetScope,
-            self.chkPlanetScopeOrtho,
             self.chkRapidEyeScene,
             self.chkRapidEyeOrtho,
             self.chkSkySatScene,

--- a/planet_explorer/gui/pe_results_configuration_dialog.py
+++ b/planet_explorer/gui/pe_results_configuration_dialog.py
@@ -17,6 +17,7 @@ class PlanetNodeMetadata(enum.Enum):
     SUN_AZIMUTH = "sun_azimuth"
     SUN_ELEVATION = "sun_elevation"
     QUALITY_CATEGORY = "quality_category"
+    PUBLISHING_STAGE = "publishing_stage"
 
 
 WIDGET, BASE = uic.loadUiType(
@@ -46,6 +47,7 @@ class ResultsConfigurationDialog(BASE, WIDGET):
             PlanetNodeMetadata.SUN_AZIMUTH: self.chkSunAzimuth,
             PlanetNodeMetadata.SUN_ELEVATION: self.chkSunElevation,
             PlanetNodeMetadata.QUALITY_CATEGORY: self.chkQualityCategory,
+            PlanetNodeMetadata.PUBLISHING_STAGE: self.chkPublishStage,
         }
 
         for chk in self.checkboxes.values():

--- a/planet_explorer/ui/pe_daily_filter_base.ui
+++ b/planet_explorer/ui/pe_daily_filter_base.ui
@@ -45,8 +45,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>415</width>
-        <height>968</height>
+        <width>401</width>
+        <height>1115</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -153,17 +153,17 @@ have access to order with my current plan</string>
            </property>
            <property name="dateTime">
             <datetime>
-             <hour>23</hour>
+             <hour>22</hour>
              <minute>0</minute>
              <second>0</second>
              <year>1999</year>
              <month>12</month>
-             <day>15</day>
+             <day>13</day>
             </datetime>
            </property>
            <property name="time">
             <time>
-             <hour>23</hour>
+             <hour>22</hour>
              <minute>0</minute>
              <second>0</second>
             </time>
@@ -499,6 +499,83 @@ have access to order with my current plan</string>
                  <widget class="QCheckBox" name="chkYellow">
                   <property name="text">
                    <string>Coastal blue, green II, yellow, red edge</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QLabel" name="lblPublishFilter">
+                  <property name="styleSheet">
+                   <string notr="true"/>
+                  </property>
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Publishing filter&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="lblLearnMorePublishFilter">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://developers.planet.com/docs/apis/data/items-assets/#item-publishing-lifecycle&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Learn More&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="openExternalLinks">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_16">
+                <item>
+                 <widget class="QCheckBox" name="cb_publish_preview_3">
+                  <property name="text">
+                   <string>Preview (unrectified)</string>
+                  </property>
+                  <property name="api-publish" stdset="0">
+                   <string>preview</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="cb_publish_standard_3">
+                  <property name="text">
+                   <string>Standard (rectified)</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                  <property name="api-publish" stdset="0">
+                   <string>standard</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="cb_publish_finalized_3">
+                  <property name="text">
+                   <string>Finalized (rectified)</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                  <property name="api-publish" stdset="0">
+                   <string>finalized</string>
                   </property>
                  </widget>
                 </item>

--- a/planet_explorer/ui/pe_daily_filter_base.ui
+++ b/planet_explorer/ui/pe_daily_filter_base.ui
@@ -158,7 +158,7 @@ have access to order with my current plan</string>
              <second>0</second>
              <year>1999</year>
              <month>12</month>
-             <day>13</day>
+             <day>12</day>
             </datetime>
            </property>
            <property name="time">
@@ -536,7 +536,7 @@ have access to order with my current plan</string>
                 <item>
                  <widget class="QCheckBox" name="cb_publish_preview_3">
                   <property name="text">
-                   <string>Preview (unrectified)</string>
+                   <string>Preview</string>
                   </property>
                   <property name="api-publish" stdset="0">
                    <string>preview</string>
@@ -546,7 +546,7 @@ have access to order with my current plan</string>
                 <item>
                  <widget class="QCheckBox" name="cb_publish_standard_3">
                   <property name="text">
-                   <string>Standard (rectified)</string>
+                   <string>Standard</string>
                   </property>
                   <property name="checked">
                    <bool>true</bool>
@@ -559,7 +559,7 @@ have access to order with my current plan</string>
                 <item>
                  <widget class="QCheckBox" name="cb_publish_finalized_3">
                   <property name="text">
-                   <string>Finalized (rectified)</string>
+                   <string>Finalized</string>
                   </property>
                   <property name="checked">
                    <bool>true</bool>

--- a/planet_explorer/ui/pe_daily_filter_base.ui
+++ b/planet_explorer/ui/pe_daily_filter_base.ui
@@ -46,7 +46,7 @@
         <x>0</x>
         <y>0</y>
         <width>401</width>
-        <height>1115</height>
+        <height>1086</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -340,16 +340,6 @@ have access to order with my current plan</string>
               </widget>
              </item>
              <item>
-              <widget class="QCheckBox" name="chkPlanetScopeOrtho">
-               <property name="text">
-                <string>PlanetScope Ortho Tile</string>
-               </property>
-               <property name="api-name" stdset="0">
-                <string>PSOrthoTile</string>
-               </property>
-              </widget>
-             </item>
-             <item>
               <widget class="QCheckBox" name="chkRapidEyeScene">
                <property name="text">
                 <string>RapidEye Basic Scene</string>
@@ -512,7 +502,7 @@ have access to order with my current plan</string>
                    <string notr="true"/>
                   </property>
                   <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Publishing filter&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Publishing stage filter&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                  </widget>
                 </item>

--- a/planet_explorer/ui/results_configuration_dialog.ui
+++ b/planet_explorer/ui/results_configuration_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>528</width>
-    <height>302</height>
+    <height>378</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -82,10 +82,17 @@ Unselect a data element to add another when 4 are selected</string>
      <property name="verticalSpacing">
       <number>20</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="chkAreaCover">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="chkSunAzimuth">
        <property name="text">
-        <string>Area Cover %</string>
+        <string>Sun Azimuth</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="chkGroundSampleDistance">
+       <property name="text">
+        <string>Ground Sample Distance</string>
        </property>
       </widget>
      </item>
@@ -93,13 +100,6 @@ Unselect a data element to add another when 4 are selected</string>
       <widget class="QCheckBox" name="chkSatelliteId">
        <property name="text">
         <string>Satellite ID</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="chkSunAzimuth">
-       <property name="text">
-        <string>Sun Azimuth</string>
        </property>
       </widget>
      </item>
@@ -117,17 +117,17 @@ Unselect a data element to add another when 4 are selected</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="chkGroundSampleDistance">
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="chkGroundControl">
        <property name="text">
-        <string>Ground Sample Distance</string>
+        <string>Ground Control</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="chkOffNadirAngle">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="chkAreaCover">
        <property name="text">
-        <string>Off-nadir Angle</string>
+        <string>Area Cover %</string>
        </property>
       </widget>
      </item>
@@ -145,10 +145,17 @@ Unselect a data element to add another when 4 are selected</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="chkGroundControl">
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="chkOffNadirAngle">
        <property name="text">
-        <string>Ground Control</string>
+        <string>Off-nadir Angle</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QCheckBox" name="chkPublishStage">
+       <property name="text">
+        <string>Publishing Stage</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Fixes #132 

- An option has been added to the Search filter for the user to choose a Publishing stage type: preview, standard, and finalized
- Standard and finalized is default
- Added only to the PlanetScope section as asked by the client
- Metadata view option added so that the user can see the Publishing stage in the search results

Filtering added:
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/1484782f-b9fd-45ba-aaf7-42c92497ecc9)

Metadata option:
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/4800e24c-9610-4201-8352-fe781725dc8a)

Metadata in search"
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/850a14fc-f5b3-4c4f-a459-fef9b5a3315d)

