### PR TITLE
Composite checkout function for orders

### DIFF
--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -954,25 +954,12 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
             return
         name = self.txtOrderName.text()
 
-        print("tool resources")
-        print(str(self.tool_resources))
-
         aoi = None
         if self.tool_resources.get("aoi") is not None:
             aoi = json.loads(self.tool_resources.get("aoi"))
 
-        print('aoi')
-        print(str(aoi))
-
         orders = []
         for item_type, widget in self._item_type_widgets.items():
-
-            # item_type2 = item_type
-            #
-            # print('item type: ' + str(item_type))
-            # if item_type == "PSScene":
-            #     item_type2 = "PSScene4Band"
-
             for bundle in widget.bundles():
                 w = self._review_widget_for_bundle(item_type, bundle["name"])
                 images = w.selected_images()
@@ -1002,9 +989,6 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
                 if w.clipping():
                     tools.append({"clip": {"aoi": aoi}})
                 if w.composite():
-
-                    print('composite')
-
                     # 'order' or 'strip_id' for 'group_by'
                     composite_type = w.getCompositeType()
                     tools.append({"composite": {"group_by": composite_type}})
@@ -1015,19 +999,8 @@ class PlanetOrdersDialog(ORDERS_BASE, ORDERS_WIDGET):
                 order["tools"] = tools
                 orders.append(order)
 
-        print('orders')
-        print(str(orders))
-
         responses_ok = True
         for order in orders:
-
-            print("order")
-            print(str(order))
-            # print(str(self._p_client))
-
-            #test = json.dumps(order)
-            #test2 = json.loads(test)
-
             resp = self._p_client.create_order(order)
             responses_ok = responses_ok and resp
             send_analytics_for_order(order)

--- a/planet_explorer/gui/pe_orders.py
+++ b/planet_explorer/gui/pe_orders.py
@@ -136,9 +136,6 @@ class PlanetOrderBundleWidget(QFrame):
         self.can_harmonize = bundle.get("canHarmonize", False)
         self.can_clip = bundle.get("canClip", False)
 
-        # =========================================================== Currently the bundle does not contain a canComposite
-        self.can_composite = bundle.get("canComposite", False)
-
         self.rectified = bundle["rectification"] == "orthorectified"
         bands = []
         asset_def = PlanetClient.getInstance().asset_types_for_item_type_as_dict(
@@ -536,7 +533,8 @@ class PlanetOrderReviewWidget(QWidget):
             description_label = QLabel(
                 "The "
                 "<a style='color: #50a94e; text-decoration: none;' "
-                "href='https://developers.planet.com/apis/orders/tools/#composite'>Composite tool</a>"
+                "href='https://developers.planet.com/apis/orders/tools/#composite'>"
+                "Composite tool</a>"
                 " allows your to composite a "
                 "set of images into a single output"
             )

--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -442,7 +442,9 @@ class OrderItemWidget(QWidget):
                     else:
                         # A workaround for composite
                         image_path = json_file["path"]
-                        if not image_path.startswith("composite."):
+                        if not image_path.endswith(
+                            "composite.tif"
+                        ) and not image_path.endswith("composite_file_format.ntf"):
                             # Skips if it's not a composite file
                             continue
 

--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -428,15 +428,23 @@ class OrderItemWidget(QWidget):
             list_files = manifest_data["files"]
             for json_file in list_files:
                 media_type = json_file["media_type"]
-
                 raster_types = ["image/tiff", "application/vnd.lotus-notes"]
 
                 if media_type in raster_types:
                     annotations = json_file["annotations"]
-                    asset_type = annotations["planet/asset_type"]
-                    if asset_type.endswith("_udm") or asset_type.endswith("_udm2"):
-                        # Skips all 'udm' asset rasters
-                        continue
+                    asset_type_key = "planet/asset_type"
+
+                    if asset_type_key in annotations:
+                        asset_type = annotations[asset_type_key]
+                        if asset_type.endswith("_udm") or asset_type.endswith("_udm2"):
+                            # Skips all 'udm' asset rasters
+                            continue
+                    else:
+                        # A workaround for composite
+                        image_path = json_file["path"]
+                        if not image_path.startswith("composite."):
+                            # Skips if it's not a composite file
+                            continue
 
                     image_path = json_file["path"]
                     image_dir = "{}/{}".format(final_path, image_path)

--- a/planet_explorer/pe_analytics.py
+++ b/planet_explorer/pe_analytics.py
@@ -104,6 +104,7 @@ def analytics_track(event, properties=None):
 
 
 item_type_names = {
+    "PSScene": "planetscope_scene",
     "PSScene4Band": "planetscope_scene",
     "PSScene3Band": "planetscope_scene",
     "PSOrthoTile": "planetscope_ortho",
@@ -148,15 +149,29 @@ def send_analytics_for_preview(imgs):
 
 
 def send_analytics_for_order(order):
+
+    print('send analytics')
+
     product = order["products"][0]
     name = item_type_names.get(product["item_type"])
+
+    #print('item type: ' + product["item_type"])
+
+    #print('name: ' + name)
+
     if name is not None:
+
+        print('name is not none')
+
         analytics_track(
             SCENE_ORDER_PLACED,
             {"count": len(product["item_ids"]), "item_type": name},
         )
         clipping = "clip" in [list(tool.keys())[0] for tool in order["tools"]]
         if clipping:
+
+            print('clipping')
+
             analytics_track(
                 SCENE_ORDER_CLIPPED,
                 {"scene_count": len(product["item_ids"]), "item_type": name},

--- a/planet_explorer/pe_analytics.py
+++ b/planet_explorer/pe_analytics.py
@@ -149,29 +149,16 @@ def send_analytics_for_preview(imgs):
 
 
 def send_analytics_for_order(order):
-
-    print('send analytics')
-
     product = order["products"][0]
     name = item_type_names.get(product["item_type"])
 
-    #print('item type: ' + product["item_type"])
-
-    #print('name: ' + name)
-
     if name is not None:
-
-        print('name is not none')
-
         analytics_track(
             SCENE_ORDER_PLACED,
             {"count": len(product["item_ids"]), "item_type": name},
         )
         clipping = "clip" in [list(tool.keys())[0] for tool in order["tools"]]
         if clipping:
-
-            print('clipping')
-
             analytics_track(
                 SCENE_ORDER_CLIPPED,
                 {"scene_count": len(product["item_ids"]), "item_type": name},

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -109,6 +109,7 @@ ORDERS_DOWNLOAD_FOLDER_SETTING = "ordersPath"
 DEFAULT_ORDERS_FOLDERNAME = "planet_orders"
 ENABLE_CLIP_SETTING = "enableClip"
 ENABLE_STAC_METADATA = "enableStacMetadata"
+ENABLE_COMPOSITE = "enableComposite"
 ENABLE_HARMONIZATION_SETTING = "enableHarmonization"
 
 BASE_URL = "https://www.planet.com"

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -266,6 +266,9 @@ class PlanetClient(QObject, ClientV1):
         return item_descriptions
 
     def create_order(self, request):
+
+        print('create order')
+
         api_key = PlanetClient.getInstance().api_key()
         url = self._url("compute/ops/orders/v2")
         headers = {"X-Planet-App": "qgis"}

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -271,7 +271,8 @@ class PlanetClient(QObject, ClientV1):
         headers = {"X-Planet-App": "qgis"}
         session = PlanetClient.getInstance().dispatcher.session
         res = session.post(url, auth=(api_key, ""), json=request, headers=headers)
-        return res.json()
+
+        return res
 
     def update_search(self, request, searchid):
         body = json.dumps(request)

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -266,9 +266,6 @@ class PlanetClient(QObject, ClientV1):
         return item_descriptions
 
     def create_order(self, request):
-
-        print('create order')
-
         api_key = PlanetClient.getInstance().api_key()
         url = self._url("compute/ops/orders/v2")
         headers = {"X-Planet-App": "qgis"}

--- a/planet_explorer/planet_api/p_order_tasks.py
+++ b/planet_explorer/planet_api/p_order_tasks.py
@@ -122,7 +122,9 @@ class OrderProcessorTask(QgsTask):
                 else:
                     # A workaround for composite
                     image_path = img["path"]
-                    if not image_path.startswith("composite."):
+                    if not image_path.endswith(
+                        "composite.tif"
+                    ) and not image_path.endswith("composite_file_format.ntf"):
                         # Skips if it's not a composite file
                         continue
                     else:

--- a/planet_explorer/planet_api/p_order_tasks.py
+++ b/planet_explorer/planet_api/p_order_tasks.py
@@ -109,12 +109,30 @@ class OrderProcessorTask(QgsTask):
         images = []
         for img in manifest["files"]:
             if img["media_type"] == "image/tiff":
-                images.append(
-                    (
-                        os.path.join(base_folder, img["path"]),
-                        img["annotations"]["planet/item_type"],
+                annotations = img["annotations"]
+                asset_type_key = "planet/asset_type"
+
+                if asset_type_key in annotations:
+                    images.append(
+                        (
+                            os.path.join(base_folder, img["path"]),
+                            img["annotations"]["planet/item_type"],
+                        )
                     )
-                )
+                else:
+                    # A workaround for composite
+                    image_path = img["path"]
+                    if not image_path.startswith("composite."):
+                        # Skips if it's not a composite file
+                        continue
+                    else:
+                        # Adds the composite file
+                        images.append(
+                            (
+                                os.path.join(base_folder, img["path"]),
+                                "composite",  # Item type
+                            )
+                        )
         return images
 
     def finished(self, result):


### PR DESCRIPTION
Fixes #131 

Adds an option for the user when applying for an order to composite the satellite data. This is based on how it looks in ArcMap (example received).

- Composite button on step 3 of the order
- Adds the composite json to tools if enabled
- Composite type allowed
- Manifest file reading had to be updated to accommodate composite cases
- Processing of the data after the download finished has been updated to accommodate composite rasters

Composite option:
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/7a808c24-3ea1-40dd-8d22-917da6141a35)

Composite raster added to canvas using the Add to map button:
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/22802ba1-378c-4bf3-93bc-6e1082d03af1)

