### PR TITLE
Publishing stage filtering will now only apply to SkySat and PlanetScope data

### DIFF
--- a/planet_explorer/gui/pe_dailyimages_widget.py
+++ b/planet_explorer/gui/pe_dailyimages_widget.py
@@ -24,11 +24,7 @@ __revision__ = "$Format:%H$"
 import logging
 import os
 
-from planet.api.filters import (
-    and_filter,
-    or_filter,
-    build_search_request,
-)
+from planet.api.filters import and_filter, or_filter, build_search_request
 from qgis.core import Qgis, QgsApplication
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSlot
@@ -51,6 +47,7 @@ from .pe_show_curl_dialog import ShowCurlDialog
 from .pe_legacy_warning_widget import LegacyWarningWidget
 from .pe_open_saved_search_dialog import OpenSavedSearchDialog
 from .pe_gui_utils import waitcursor
+from ..pe_utils import LANDSAT_ID, SENTINEL_ID, RAPIDEYE_ID, RAPIDEYE_ORTHO_ID
 
 LOG_LEVEL = os.environ.get("PYTHON_LOG_LEVEL", "WARNING").upper()
 logging.basicConfig(level=LOG_LEVEL)
@@ -202,10 +199,10 @@ class DailyImagesWidget(BASE, WIDGET):
 
         # RapidEye, Landsat and Sentinel does not have a publishing stage field
         non_publish_filter_items = [
-            "Landsat8L1G",
-            "Sentinel2L1C",
-            "REScene",
-            "REOrthoTile",
+            LANDSAT_ID,
+            SENTINEL_ID,
+            RAPIDEYE_ID,
+            RAPIDEYE_ORTHO_ID,
         ]
 
         item_type_filters = []

--- a/planet_explorer/gui/pe_dailyimages_widget.py
+++ b/planet_explorer/gui/pe_dailyimages_widget.py
@@ -28,7 +28,6 @@ from planet.api.filters import (
     and_filter,
     or_filter,
     build_search_request,
-    string_filter,
 )
 from qgis.core import Qgis, QgsApplication
 from qgis.PyQt import uic

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1309,7 +1309,7 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
             self.cb_publish_finalized_3,
         ]:
             # preview, standard and finalized
-            if chk.isChecked():
+            if chk.isChecked() and chk.isEnabled():
                 publish_types.append(chk.property("api-publish"))
         if publish_types:
             # Adds the Publishing stage to the filters if any were active

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1302,6 +1302,7 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
 
         # Publishing stage
         publish_types = []
+        publish_filters = None
         for chk in [
             self.cb_publish_preview_3,
             self.cb_publish_standard_3,
@@ -1313,8 +1314,8 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
         if publish_types:
             # Adds the Publishing stage to the filters if any were active
             # Metadata name is "publishing_stage"
+            # Publising stage filters will only be used for SkySat and PlanetScope
             publish_filters = string_filter("publishing_stage", *publish_types)
-            populated_filters.append(publish_filters)
 
         instruments = []
         for chk in [self.chkPs2, self.chkPs2Sd, self.chkPsbSd]:
@@ -1345,7 +1346,7 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
         local_filters = [
             f for f in populated_filters if f["field_name"] in LOCAL_FILTERS
         ]
-        return server_filters, local_filters
+        return server_filters, local_filters, publish_filters
 
     def set_from_request(self, request):
         """

--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1304,9 +1304,9 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
         publish_types = []
         publish_filters = None
         for chk in [
-            self.cb_publish_preview_3,
-            self.cb_publish_standard_3,
-            self.cb_publish_finalized_3,
+            self.cb_publish_preview,
+            self.cb_publish_standard,
+            self.cb_publish_finalized,
         ]:
             # preview, standard and finalized
             if chk.isChecked() and chk.isEnabled():
@@ -1314,7 +1314,7 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
         if publish_types:
             # Adds the Publishing stage to the filters if any were active
             # Metadata name is "publishing_stage"
-            # Publising stage filters will only be used for SkySat and PlanetScope
+            # Publishing stage filters will only be used for SkySat and PlanetScope
             publish_filters = string_filter("publishing_stage", *publish_types)
 
         instruments = []

--- a/planet_explorer/pe_utils.py
+++ b/planet_explorer/pe_utils.py
@@ -92,6 +92,11 @@ PROPERTIES = [
     "quality_category",
 ]
 
+LANDSAT_ID = "Landsat8L1G"
+SENTINEL_ID = "Sentinel2L1C"
+RAPIDEYE_ID = "REScene"
+RAPIDEYE_ORTHO_ID = "REOrthoTile"
+
 PE_PREVIEW = "PE thumbnail preview"
 PE_PREVIEW_GROUP = "Planet Explorer temp previews"
 

--- a/planet_explorer/ui/pe_daily_filter_base.ui
+++ b/planet_explorer/ui/pe_daily_filter_base.ui
@@ -158,7 +158,7 @@ have access to order with my current plan</string>
              <second>0</second>
              <year>1999</year>
              <month>12</month>
-             <day>12</day>
+             <day>11</day>
             </datetime>
            </property>
            <property name="time">
@@ -534,7 +534,7 @@ have access to order with my current plan</string>
               <item>
                <layout class="QVBoxLayout" name="verticalLayout_16">
                 <item>
-                 <widget class="QCheckBox" name="cb_publish_preview_3">
+                 <widget class="QCheckBox" name="cb_publish_preview">
                   <property name="text">
                    <string>Preview</string>
                   </property>
@@ -544,7 +544,7 @@ have access to order with my current plan</string>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QCheckBox" name="cb_publish_standard_3">
+                 <widget class="QCheckBox" name="cb_publish_standard">
                   <property name="text">
                    <string>Standard</string>
                   </property>
@@ -557,7 +557,7 @@ have access to order with my current plan</string>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QCheckBox" name="cb_publish_finalized_3">
+                 <widget class="QCheckBox" name="cb_publish_finalized">
                   <property name="text">
                    <string>Finalized</string>
                   </property>


### PR DESCRIPTION
Fixes #137 

- When the Publishing stage filter where active, the search results will not include Landsat or Sentinel data
- Additional testing showed that the same happens with RapidEye
- The reasons for this is because neither of these satellite images has the "Publish stage" filtering option
- The "Publish stage" filtering will now only apply to SkySat and PlanetScope, as those are the only data which has this field in the metadata

PlanetScope footprint data (Publishing stage included):
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/d1f52904-f2c1-4178-95c6-22204fb724db)

Landsat footprint data (no publishing stage):
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/87f4e78b-e4d4-4332-8b74-f782d94c8eed)

Results with PlanetScope, SkySat and Landsat:
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/71f319de-99e0-48ce-9bf2-f7fb48012363)

Results with Landsat and Sentinel:
![image](https://github.com/planetlabs/qgis-planet-plugin/assets/79740955/29c4e674-0013-4ba0-8935-dc65cb4a8a50)
