### PR TITLE
Fix streaming basemaps when using saved project

### DIFF
--- a/planet_explorer/gui/pe_basemap_layer_widget.py
+++ b/planet_explorer/gui/pe_basemap_layer_widget.py
@@ -368,6 +368,9 @@ class BasemapLayerWidget(QWidget):
             res = pattern.search(unquote(self.layer.source()))
             passed_api_key = res.groups()[0] if res.groups() else None
 
+            if '&' in passed_api_key:
+                passed_api_key = passed_api_key.split('&')[0]
+
             has_api_key = PlanetClient.getInstance().has_api_key()
 
             # The label warning should only be shown if a logged-in user doesn't
@@ -378,7 +381,7 @@ class BasemapLayerWidget(QWidget):
 
             api_key = (
                 PlanetClient.getInstance().api_key()
-                if not passed_api_key
+                if not passed_api_key or passed_api_key is ''
                 else passed_api_key
             )
 


### PR DESCRIPTION
When user logouts and then opens a saved project that contained a streamed basemap the target layer doesn't get rendered even after when user login again. This PR provides a fix for the issue by making sure the API key is added to the layer URI when rendering the streamed basemap.

Screenshot of the issue before the fix

https://github.com/planetlabs/qgis-planet-plugin/assets/2663775/c05f04a8-59c8-46c8-8ed6-ded61b7017ea

Screenshot after apply the fix

https://github.com/planetlabs/qgis-planet-plugin/assets/2663775/b8cd44e5-af87-421a-b3e1-9de521e145e2


