### PR TITLE
Deprecation of Sentinel & LandSat search filters

### DIFF
--- a/planet_explorer/gui/pe_filters.py
+++ b/planet_explorer/gui/pe_filters.py
@@ -1137,8 +1137,6 @@ class PlanetDailyFilter(DAILY_BASE, DAILY_WIDGET, PlanetFilterMixin):
             self.chkRapidEyeOrtho,
             self.chkSkySatScene,
             self.chkSkySatCollect,
-            self.chkLandsat,
-            self.chkSentinel,
         ]
 
         for source in self.itemTypeCheckBoxes:

--- a/planet_explorer/tests/test_daily_imagery.py
+++ b/planet_explorer/tests/test_daily_imagery.py
@@ -21,8 +21,6 @@ ITEM_TYPE_CHECKBOXES = {
     "REOrthoTile": "chkRapidEyeOrtho",
     "SkySatScene": "chkSkySatScene",
     "SkySatCollect": "chkSkySatCollect",
-    "Landsat8L1G": "chkLandsat",
-    "Sentinel2L1C": "chkSentinel",
 }
 
 SPECTRAL_BAND_CHECKBOXES = {"4Band": "chkNIR", "8Band": "chkYellow"}

--- a/planet_explorer/ui/pe_daily_filter_base.ui
+++ b/planet_explorer/ui/pe_daily_filter_base.ui
@@ -46,7 +46,7 @@
         <x>0</x>
         <y>0</y>
         <width>401</width>
-        <height>1086</height>
+        <height>1003</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -153,17 +153,17 @@ have access to order with my current plan</string>
            </property>
            <property name="dateTime">
             <datetime>
-             <hour>22</hour>
+             <hour>21</hour>
              <minute>0</minute>
              <second>0</second>
              <year>1999</year>
              <month>12</month>
-             <day>11</day>
+             <day>10</day>
             </datetime>
            </property>
            <property name="time">
             <time>
-             <hour>22</hour>
+             <hour>21</hour>
              <minute>0</minute>
              <second>0</second>
             </time>
@@ -356,43 +356,6 @@ have access to order with my current plan</string>
                </property>
                <property name="api-name" stdset="0">
                 <string>REOrthoTile</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(17, 141, 148);</string>
-             </property>
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Non-Planet Data Sets (&amp;gt;10 m)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_8">
-             <property name="leftMargin">
-              <number>10</number>
-             </property>
-             <item>
-              <widget class="QCheckBox" name="chkSentinel">
-               <property name="text">
-                <string>Sentinel-2 Tile</string>
-               </property>
-               <property name="api-name" stdset="0">
-                <string>Sentinel2L1C</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="chkLandsat">
-               <property name="text">
-                <string>Landsat 8</string>
-               </property>
-               <property name="api-name" stdset="0">
-                <string>Landsat8L1G</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Removes all non-planet datasets search filters and when users load saved searches that contain non-planet data, the non-planet data won't be loaded into the search results widget.

| Old search filters  |  New search filters |
|--------------------------|--------------------------|
|![image](https://github.com/planetlabs/qgis-planet-plugin/assets/2663775/b0d39a9a-ae65-40f6-be64-44010674402e) | ![image](https://github.com/planetlabs/qgis-planet-plugin/assets/2663775/d81e8b98-49db-4ac6-9fa6-d11a9e1b785d)|


Screenshots showing the behaviour when user try to load a non-planet data saved search with a warning message

![planet_filtering_update](https://github.com/planetlabs/qgis-planet-plugin/assets/2663775/4c83d694-f167-49cf-9214-4430eac50b32)

![image](https://github.com/planetlabs/qgis-planet-plugin/assets/2663775/c5e84e80-62ba-4a50-b1bd-86795b65d1a2)




