### PR TITLE
Include license file in the plugin zip archive

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -240,6 +240,12 @@ def _make_zip(zipfile, options):
 
         zipfile.writestr("planet_explorer/pe_utils.py", txt)
 
+    # Include the license file in the zip archive
+    license_file = os.path.join(os.path.dirname(__file__), "LICENSE")
+    with open(license_file) as f:
+        license_text = f.read()
+        zipfile.writestr("planet_explorer/LICENSE", license_text)
+
 
 @dataclass
 class GithubRelease:


### PR DESCRIPTION
Adding the LICENSE file when compressing plugin files into a zip archive.