### PR TITLE
Do not reject DefaultProxy as invalid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         mkdir tmp
         unzip planet_explorer.zip -d tmp
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: planet_explorer_${{github.sha}}
         path: tmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         mkdir tmp
         unzip planet_explorer.zip -d tmp
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: planet_explorer_${{github.sha}}
         path: tmp

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ shell.nix
 .privoxy-cache/ca-key.pem
 .privoxy-cache/ca-cert.pem
 .privoxy.pid
+scripts/list_proxies.py

--- a/pavement.py
+++ b/pavement.py
@@ -26,6 +26,7 @@ import os
 import subprocess
 import sys
 import zipfile
+
 from configparser import ConfigParser
 from io import StringIO
 
@@ -213,7 +214,7 @@ def _make_zip(zipfile, options):
     metadata_filename = os.path.join(
         os.path.dirname(__file__), "planet_explorer", "metadata.txt"
     )
-    cfg = SafeConfigParser()
+    cfg = ConfigParser()
     cfg.optionxform = str
     cfg.read(metadata_filename)
 

--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -22,6 +22,8 @@ repository=https://github.com/planetlabs/qgis-planet-plugin
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
+  v2.3.5 (2025-06-18)
+  * Support DefaultProxy type
   v2.3.4 (2024-07-11)
   * Removed support for non-Planet datasets search filters.
   v2.3.3 (2024-04-12)

--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -7,7 +7,7 @@
 name=Planet_Explorer
 qgisMinimumVersion=3.10
 description=The Planet Plugin enables QGIS users to quickly discover, stream, and download Planet imagery and Planet Basemaps. The plug-in provides an imagery discovery interface that allows users to search for, stream, and download Planet imagery within QGIS.<br><br>Full documentation for the Plugin is available <a href="https://developers.planet.com/docs/integrations/qgis/">here</a>.
-version=dev
+version=2.3.5
 author=Planet Inc
 email=support@planet.com
 

--- a/planet_explorer/pe_plugin.py
+++ b/planet_explorer/pe_plugin.py
@@ -150,7 +150,11 @@ class PlanetExplorer(object):
         self.plugin_dir = os.path.dirname(__file__)
 
         # Initialize locale
-        locale = QSettings().value("locale/userLocale", QLocale().name())[0:2]
+        locale_value = QSettings().value("locale/userLocale", QLocale().name())
+        if isinstance(locale_value, str):
+            locale = locale_value[0:2]
+        else:
+            locale = str(locale_value)[0:2]
         locale_path = os.path.join(
             self.plugin_dir, "i18n", "{0}Plugin_{1}.qm".format(PE, locale)
         )

--- a/scripts/privoxy.sh
+++ b/scripts/privoxy.sh
@@ -47,9 +47,11 @@ case "$CMD" in
 listen-address  127.0.0.1:8123
 logdir $PRIVOXY_CACHE_DIR
 confdir $PRIVOXY_CACHE_DIR
-enable-ssl-intercept 1
 ca-key-file $PRIVOXY_CA_KEY_FILE
 ca-cert-file $PRIVOXY_CA_CERT_FILE
+logfile privoxy.log
+debug   1
+debug   1024
 EOF
         fi
         if [ ! -f "$PRIVOXY_PID_FILE" ] || ! kill -0 "$(cat "$PRIVOXY_PID_FILE")" 2>/dev/null; then


### PR DESCRIPTION
This change allows the user to set the proxy type in QGIS to DefaultProxy and still connect to Planet to log in with the plugin.
It also bumps the version to 2.3.5 and fixes a bug in the pe_plugin.py module that was causing an error message on some systems.
Finally it includes a launcher script for privoxy to create a local test environment for http proxy support.