### PR TITLE
Version 2.3.6: Use QGIS network stack and improve connectivity handling

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        qgis_version: [ "3.44", "3.42", "3.40", "3.38", "release-3_36" ]
+        qgis_version: [ "3.44", "3.42", "3.40", "3.38" ]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ shell.nix
 .privoxy-cache/ca-cert.pem
 .privoxy.pid
 scripts/list_proxies.py
+codeql-db
+.claude
+.pac-server.pid
+proxy.pac
+core

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
           pkgs.qt5.qtsvg
           pkgs.qt5.qttools
           pkgs.skate # Distributed key/value store
+          pkgs.tailspin # Beautiful log tailing with syntax highlighting
           pkgs.vim
           pkgs.virtualenv
           pkgs.vscode

--- a/planet_explorer/gui/pe_explorer_dockwidget.py
+++ b/planet_explorer/gui/pe_explorer_dockwidget.py
@@ -333,6 +333,7 @@ def _get_widget_instance():
     global dockwidget_instance
     if dockwidget_instance is None:
         dockwidget_instance = PlanetExplorerDockWidget(parent=iface.mainWindow())
+        dockwidget_instance.setObjectName("PlanetExplorerDockWidget")
         dockwidget_instance.setAllowedAreas(
             Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
         )

--- a/planet_explorer/gui/pe_explorer_dockwidget.py
+++ b/planet_explorer/gui/pe_explorer_dockwidget.py
@@ -187,6 +187,8 @@ class PlanetExplorerDockWidget(BASE, WIDGET):
             )
             # Stay on login panel if error
             return
+        except Exception:
+            return
         finally:
             self.p_client.blockSignals(False)
 

--- a/planet_explorer/gui/pe_orders_monitor_dockwidget.py
+++ b/planet_explorer/gui/pe_orders_monitor_dockwidget.py
@@ -575,6 +575,7 @@ def _get_widget_instance():
         if not PlanetClient.getInstance().has_api_key():
             return None
         dockwidget_instance = PlanetOrdersMonitorDockWidget(parent=iface.mainWindow())
+        dockwidget_instance.setObjectName("PlanetOrdersMonitorDockWidget")
         dockwidget_instance.setAllowedAreas(
             Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
         )

--- a/planet_explorer/gui/pe_planet_inspector_dockwidget.py
+++ b/planet_explorer/gui/pe_planet_inspector_dockwidget.py
@@ -388,6 +388,7 @@ def _get_widget_instance():
         if not PlanetClient.getInstance().has_api_key():
             return None
         dockwidget_instance = PlanetInspectorDockWidget(parent=iface.mainWindow())
+        dockwidget_instance.setObjectName("PlanetInspectorDockWidget")
         dockwidget_instance.setAllowedAreas(
             Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
         )

--- a/planet_explorer/gui/pe_tasking_dockwidget.py
+++ b/planet_explorer/gui/pe_tasking_dockwidget.py
@@ -242,6 +242,7 @@ def _get_widget_instance():
         if not PlanetClient.getInstance().has_api_key():
             return None
         dockwidget_instance = TaskingDockWidget(parent=iface.mainWindow())
+        dockwidget_instance.setObjectName("PlanetTaskingDockWidget")
         dockwidget_instance.setAllowedAreas(
             Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea
         )

--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -22,6 +22,8 @@ repository=https://github.com/planetlabs/qgis-planet-plugin
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
+  v2.3.6 (2025-12-02)
+  * Use QgsBlockingNetworkRequest for API calls.
   v2.3.5 (2025-06-18)
   * Support DefaultProxy type
   v2.3.4 (2024-07-11)

--- a/planet_explorer/metadata.txt
+++ b/planet_explorer/metadata.txt
@@ -7,7 +7,7 @@
 name=Planet_Explorer
 qgisMinimumVersion=3.10
 description=The Planet Plugin enables QGIS users to quickly discover, stream, and download Planet imagery and Planet Basemaps. The plug-in provides an imagery discovery interface that allows users to search for, stream, and download Planet imagery within QGIS.<br><br>Full documentation for the Plugin is available <a href="https://developers.planet.com/docs/integrations/qgis/">here</a>.
-version=2.3.5
+version=2.3.6
 author=Planet Inc
 email=support@planet.com
 

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -88,7 +88,20 @@ class QGISAdapter:
             if not QGISAdapter._offline:
                 QGISAdapter._offline = True
                 msg_lower = msg.lower()
-                if "proxy" in msg_lower:
+                if "ssl" in msg_lower or "tls" in msg_lower:
+                    if "proxy" in msg_lower:
+                        bar_msg = (
+                            "SSL/TLS error connecting to Planet via proxy. "
+                            "Your proxy may be interfering with HTTPS. "
+                            "Check Settings > Options > Network."
+                        )
+                    else:
+                        bar_msg = (
+                            "SSL/TLS error connecting to Planet. If you are "
+                            "using a proxy, it may be interfering with HTTPS "
+                            "connections."
+                        )
+                elif "proxy" in msg_lower:
                     bar_msg = (
                         "Proxy connection refused. Check your proxy "
                         "settings under Settings > Options > Network."

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -32,9 +32,9 @@ from typing import (
     Optional,
     List,
 )
-from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QObject, QUrl
+from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QObject, QUrl, QMetaObject, Qt
 from PyQt5.QtNetwork import QNetworkRequest
-from qgis.core import QgsBlockingNetworkRequest
+from qgis.core import Qgis, QgsBlockingNetworkRequest
 
 import requests
 
@@ -64,7 +64,12 @@ class LoginException(Exception):
 
 
 class QGISAdapter:
+
+    _offline = False
+    _message_bar_item = None
+
     def send(self, request: requests.PreparedRequest, **kwargs):
+        error = 0
         req = QNetworkRequest(QUrl(request.url))
         for h in request.headers:
             req.setRawHeader(h.encode(), request.headers[h].encode())
@@ -80,12 +85,44 @@ class QGISAdapter:
             error = breq.post(req, body)
         if error > 0:
             msg = breq.errorMessage()
+            if not QGISAdapter._offline:
+                QGISAdapter._offline = True
+                msg_lower = msg.lower()
+                if "proxy" in msg_lower:
+                    bar_msg = (
+                        "Proxy connection refused. Check your proxy "
+                        "settings under Settings > Options > Network."
+                    )
+                elif error == 2 or "timed out" in msg_lower or "timeout" in msg_lower:
+                    bar_msg = (
+                        "Connection to Planet timed out. The plugin will "
+                        "resume automatically when connectivity is restored."
+                    )
+                else:
+                    bar_msg = (
+                        "Cannot access the internet. The plugin will resume "
+                        "automatically when connectivity is restored."
+                    )
+                QGISAdapter._offline_msg = bar_msg
+                QMetaObject.invokeMethod(
+                    PlanetClient.getInstance(),
+                    "_show_offline_message",
+                    Qt.QueuedConnection,
+                )
             if error == 1:
                 raise requests.exceptions.ConnectionError(msg)
             elif error == 2:
                 raise requests.exceptions.ConnectTimeout(msg)
             elif error == 3:
                 raise requests.exceptions.RequestException(msg)
+
+        if QGISAdapter._offline:
+            QGISAdapter._offline = False
+            QMetaObject.invokeMethod(
+                PlanetClient.getInstance(),
+                "_clear_offline_message",
+                Qt.QueuedConnection,
+            )
 
         content = breq.reply()
         resp = requests.Response()
@@ -139,6 +176,39 @@ class PlanetClient(QObject, ClientV1):
         self._bundles = None
         self._asset_types = {}
         self.dispatcher.session.mount("https://", QGISAdapter())
+
+    @pyqtSlot()
+    def _show_offline_message(self):
+        from ..pe_utils import iface, PLANET_COLOR
+
+        if QGISAdapter._message_bar_item is None:
+            msg = getattr(QGISAdapter, "_offline_msg", "Cannot access the internet.")
+            QGISAdapter._message_bar_item = iface.messageBar().createMessage(
+                "Planet Explorer",
+                msg,
+            )
+            QGISAdapter._message_bar_item.setStyleSheet(
+                "QgsMessageBarItem {{ background-color: rgb({r},{g},{b}); "
+                "color: white; }}".format(
+                    r=PLANET_COLOR.red(), g=PLANET_COLOR.green(), b=PLANET_COLOR.blue()
+                )
+            )
+            iface.messageBar().pushWidget(
+                QGISAdapter._message_bar_item, Qgis.Warning, 0
+            )
+
+    @pyqtSlot()
+    def _clear_offline_message(self):
+        from ..pe_utils import iface
+        import sip
+
+        if QGISAdapter._message_bar_item is not None:
+            try:
+                if not sip.isdeleted(QGISAdapter._message_bar_item):
+                    iface.messageBar().popWidget(QGISAdapter._message_bar_item)
+            except RuntimeError:
+                pass
+            QGISAdapter._message_bar_item = None
 
     @waitcursor
     def log_in(self, user, password, api_key=None):

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -21,6 +21,7 @@ __copyright__ = "(C) 2019 Planet Inc, https://planet.com"
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = "$Format:%H$"
 
+import gzip
 import os
 import re
 import logging
@@ -31,11 +32,11 @@ from typing import (
     Optional,
     List,
 )
-from urllib.parse import urlparse
-import urllib
-from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QObject, QSettings
-from qgis.core import QgsAuthMethodConfig, QgsApplication, QgsMessageLog, Qgis
+from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QObject, QUrl
+from PyQt5.QtNetwork import QNetworkRequest
+from qgis.core import QgsBlockingNetworkRequest
 
+import requests
 
 from planet.api import ClientV1, auth
 from planet.api import models as api_models
@@ -62,6 +63,43 @@ class LoginException(Exception):
     pass
 
 
+class QGISAdapter:
+    def send(self, request: requests.PreparedRequest, **kwargs):
+        req = QNetworkRequest(QUrl(request.url))
+        for h in request.headers:
+            req.setRawHeader(h.encode(), request.headers[h].encode())
+        req.setRawHeader("Accept-Encoding".encode(), "gzip".encode())
+
+        breq = QgsBlockingNetworkRequest()
+        if request.method == "GET":
+            error = breq.get(req)
+        elif request.method == "POST":
+            body = request.body
+            if not isinstance(body, bytes):
+                body = body.encode()
+            error = breq.post(req, body)
+        if error > 0:
+            msg = breq.errorMessage()
+            if error == 1:
+                raise requests.exceptions.ConnectionError(msg)
+            elif error == 2:
+                raise requests.exceptions.ConnectTimeout(msg)
+            elif error == 3:
+                raise requests.exceptions.RequestException(msg)
+
+        content = breq.reply()
+        resp = requests.Response()
+        for h in content.rawHeaderList():
+            header = h.data().decode()
+            resp.headers[header] = content.rawHeader(h).data().decode()
+        data = content.content().data()
+        if resp.headers["Content-Encoding"] == "gzip":
+            data = gzip.decompress(data)
+        resp._content = data
+        resp.status_code = content.attribute(QNetworkRequest.HttpStatusCodeAttribute)
+        return resp
+
+
 class PlanetClient(QObject, ClientV1):
     """
     Wrapper class for ``planet`` Python package, to abstract calls and make it
@@ -77,7 +115,6 @@ class PlanetClient(QObject, ClientV1):
         if PlanetClient.__instance is None:
             PlanetClient()
 
-        PlanetClient.__instance.set_proxy_values()
         return PlanetClient.__instance
 
     def __init__(self):
@@ -101,65 +138,7 @@ class PlanetClient(QObject, ClientV1):
         self._item_types = None
         self._bundles = None
         self._asset_types = {}
-
-    def set_proxy_values(self):
-        settings = QSettings()
-        proxyEnabled = settings.value("proxy/proxyEnabled")
-        base_url = self.base_url.lower()
-        excluded = False
-        noProxyUrls = settings.value("proxy/noProxyUrls") or []
-        excluded = any([base_url.startswith(url.lower()) for url in noProxyUrls])
-        if proxyEnabled and not excluded:
-            proxyType = settings.value("proxy/proxyType")
-            if proxyType == "DefaultProxy":
-                # Try to get system proxy settings
-
-                proxies = urllib.request.getproxies()
-                proxy_url = proxies.get("http") or proxies.get("https")
-                if proxy_url:
-                    # Parse proxy_url, e.g. http://host:port
-                    parsed = urlparse(proxy_url)
-                    proxyHost = parsed.hostname
-                    proxyPort = parsed.port
-                else:
-                    QgsMessageLog.logMessage(
-                        "Planet Explorer: No system proxy found for 'DefaultProxy' proxy type.",
-                        level=Qgis.Warning,
-                    )
-                    return
-            elif proxyType == "HttpProxy":
-                proxyHost = settings.value("proxy/proxyHost")
-                proxyPort = settings.value("proxy/proxyPort")
-            else:
-                QgsMessageLog.logMessage(
-                    "Planet Explorer: Only 'HttpProxy' or 'Default' "
-                    "QGIS Proxy options are supported "
-                    "for connecting to the Planet API.",
-                    level=Qgis.Warning,
-                )
-                return
-
-            url = f"{proxyHost}:{proxyPort}"  # noqa
-            authid = settings.value("proxy/authcfg", "")
-            if authid:
-                authConfig = QgsAuthMethodConfig()
-                QgsApplication.authManager().loadAuthenticationConfig(
-                    authid, authConfig, True
-                )
-                username = authConfig.config("username")
-                password = authConfig.config("password")
-            else:
-                username = settings.value("proxy/proxyUser")
-                password = settings.value("proxy/proxyPassword")
-
-            if username:
-                tokens = url.split("://")
-                url = f"{tokens[0]}://{username}:{password}@{tokens[-1]}"  # noqa: E231
-
-            self.dispatcher.session.proxies["http"] = url
-            self.dispatcher.session.proxies["https"] = url
-        else:
-            self.dispatcher.session.proxies = {}
+        self.dispatcher.session.mount("https://", QGISAdapter())
 
     @waitcursor
     def log_in(self, user, password, api_key=None):

--- a/planet_explorer/planet_api/p_client.py
+++ b/planet_explorer/planet_api/p_client.py
@@ -130,7 +130,7 @@ class QGISAdapter:
             header = h.data().decode()
             resp.headers[header] = content.rawHeader(h).data().decode()
         data = content.content().data()
-        if resp.headers["Content-Encoding"] == "gzip":
+        if resp.headers.get("Content-Encoding") == "gzip":
             data = gzip.decompress(data)
         resp._content = data
         resp.status_code = content.attribute(QNetworkRequest.HttpStatusCodeAttribute)

--- a/scripts/privoxy.sh
+++ b/scripts/privoxy.sh
@@ -191,17 +191,54 @@ show_logs() {
   fi
 }
 
+test_pac_local() {
+  local url="http://127.0.0.1:$PAC_SERVER_PORT/proxy.pac"
+  echo "🧪 Fetching PAC file from localhost: $url"
+  echo ""
+  if command -v curl >/dev/null 2>&1; then
+    curl -sf "$url" && echo "" || echo "❌ Failed to fetch PAC file. Is the PAC server running?"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$url" && echo "" || echo "❌ Failed to fetch PAC file. Is the PAC server running?"
+  else
+    echo "❌ Neither curl nor wget found"
+  fi
+}
+
+test_pac_vlan() {
+  local virsh_ips
+  virsh_ips=$(get_virsh_ips)
+  if [ -z "$virsh_ips" ]; then
+    echo "❌ No virbr* interfaces found. Is libvirt running?"
+    return 1
+  fi
+  for virsh_ip in $virsh_ips; do
+    local url="http://$virsh_ip:$PAC_SERVER_PORT/proxy.pac"
+    echo "🧪 Fetching PAC file from virsh network ($virsh_ip): $url"
+    echo ""
+    if command -v curl >/dev/null 2>&1; then
+      curl -sf "$url" && echo "" || echo "❌ Failed to fetch PAC file. Is the PAC server running?"
+    elif command -v wget >/dev/null 2>&1; then
+      wget -qO- "$url" && echo "" || echo "❌ Failed to fetch PAC file. Is the PAC server running?"
+    else
+      echo "❌ Neither curl nor wget found"
+    fi
+    echo ""
+  done
+}
+
 show_help() {
-  echo "Usage: $0 {start|stop|restart|status|generate-ca|logs|help}"
+  echo "Usage: $0 {start|stop|restart|status|generate-ca|logs|testpac-local|testpac-vlan|help}"
   echo ""
   echo "Commands:"
-  echo "  start        Start privoxy with HTTPS support"
-  echo "  stop         Stop privoxy"
-  echo "  restart      Restart privoxy"
-  echo "  status       Show privoxy status"
-  echo "  generate-ca  Generate a new CA certificate for HTTPS interception"
-  echo "  logs         Follow privoxy logs (uses bat if available, otherwise tail)"
-  echo "  help         Show this help message"
+  echo "  start          Start privoxy with HTTPS support"
+  echo "  stop           Stop privoxy"
+  echo "  restart        Restart privoxy"
+  echo "  status         Show privoxy status"
+  echo "  generate-ca    Generate a new CA certificate for HTTPS interception"
+  echo "  logs           Follow privoxy logs (uses bat if available, otherwise tail)"
+  echo "  testpac-local  Fetch and display PAC file via localhost"
+  echo "  testpac-vlan   Fetch and display PAC file via virsh/libvirt bridge network"
+  echo "  help           Show this help message"
   echo ""
   echo "The CA certificate is required for HTTPS interception. After running 'generate-ca',"
   echo "import $PRIVOXY_CA_CERT_FILE into your browser/system to avoid HTTPS warnings."
@@ -261,6 +298,12 @@ generate-ca)
   ;;
 logs)
   show_logs
+  ;;
+testpac-local)
+  test_pac_local
+  ;;
+testpac-vlan)
+  test_pac_vlan
   ;;
 help | --help | -h)
   show_help

--- a/scripts/privoxy.sh
+++ b/scripts/privoxy.sh
@@ -8,43 +8,189 @@ PRIVOXY_CONFIG_FILE="$(pwd)/.privoxy-config"
 PRIVOXY_PID_FILE="$(pwd)/.privoxy.pid"
 PRIVOXY_CA_CERT_FILE="$PRIVOXY_CACHE_DIR/ca-cert.pem"
 PRIVOXY_CA_KEY_FILE="$PRIVOXY_CACHE_DIR/ca-key.pem"
+PAC_SERVER_PID_FILE="$(pwd)/.pac-server.pid"
+PAC_SERVER_PORT="8080"
 
 mkdir -p "$PRIVOXY_CACHE_DIR"
 
-generate_ca() {
-    if [ ! -f "$PRIVOXY_CA_CERT_FILE" ] || [ ! -f "$PRIVOXY_CA_KEY_FILE" ]; then
-        echo "Generating CA certificate for HTTPS inspection..."
-        openssl req -x509 -newkey rsa:2048 -days 365 -nodes \
-            -keyout "$PRIVOXY_CA_KEY_FILE" \
-            -out "$PRIVOXY_CA_CERT_FILE" \
-            -subj "/CN=Privoxy CA"
-        echo "CA certificate generated at: $PRIVOXY_CA_CERT_FILE"
-    else
-        echo "CA certificate already exists at: $PRIVOXY_CA_CERT_FILE"
+open_firewall() {
+  echo "🔥"
+  echo "🔥  SECURITY WARNING: OPENING FIREWALL"
+  echo "🔥  PORT 8123 ACCESSIBLE FROM NETWORK"
+  echo "🔥   PRIVOXY PROXY EXPOSED TO WORLD"
+  echo "🔥    USE WITH EXTREME CAUTION!!!"
+  echo "🔥"
+  sudo iptables -I INPUT -p tcp --dport 8123 -j ACCEPT
+  echo "🔓 Firewall port 8123 opened"
+}
+
+close_firewall() {
+  sudo iptables -D INPUT -p tcp --dport 8123 -j ACCEPT 2>/dev/null || true
+  echo "🔒 Firewall port 8123 closed"
+}
+
+start_pac_server() {
+  local proxy_ip=$(ip route get 1.1.1.1 | awk '{print $7}' | head -1)
+  local pac_file="$(pwd)/proxy.pac"
+
+  if [ -f "$PAC_SERVER_PID_FILE" ] && kill -0 "$(cat "$PAC_SERVER_PID_FILE")" 2>/dev/null; then
+    echo "🌐 PAC server already running (PID: $(cat "$PAC_SERVER_PID_FILE"))"
+    return 0
+  fi
+
+  # Open firewall for PAC server
+  sudo iptables -I INPUT -p tcp --dport "$PAC_SERVER_PORT" -j ACCEPT
+  echo "🔓 Firewall port $PAC_SERVER_PORT opened for PAC server"
+
+  # Start simple HTTP server for PAC file
+  if command -v python3 >/dev/null 2>&1; then
+    cd "$(dirname "$pac_file")"
+    python3 -m http.server "$PAC_SERVER_PORT" >/dev/null 2>&1 &
+    echo $! >"$PAC_SERVER_PID_FILE"
+    cd - >/dev/null
+    echo "🌐 PAC server started on port $PAC_SERVER_PORT (PID: $(cat "$PAC_SERVER_PID_FILE"))"
+    echo "   PAC URL: http://$proxy_ip:$PAC_SERVER_PORT/proxy.pac"
+  elif command -v python >/dev/null 2>&1; then
+    cd "$(dirname "$pac_file")"
+    python -m SimpleHTTPServer "$PAC_SERVER_PORT" >/dev/null 2>&1 &
+    echo $! >"$PAC_SERVER_PID_FILE"
+    cd - >/dev/null
+    echo "🌐 PAC server started on port $PAC_SERVER_PORT (PID: $(cat "$PAC_SERVER_PID_FILE"))"
+    echo "   PAC URL: http://$proxy_ip:$PAC_SERVER_PORT/proxy.pac"
+  else
+    echo "⚠️  Warning: Neither python3 nor python found - cannot start PAC server"
+    echo "   You'll need to serve the PAC file manually or use file:// URLs"
+  fi
+}
+
+stop_pac_server() {
+  if [ -f "$PAC_SERVER_PID_FILE" ]; then
+    if kill "$(cat "$PAC_SERVER_PID_FILE")" 2>/dev/null; then
+      echo "🌐 PAC server stopped"
     fi
+    rm -f "$PAC_SERVER_PID_FILE"
+  fi
+  # Close firewall for PAC server
+  sudo iptables -D INPUT -p tcp --dport "$PAC_SERVER_PORT" -j ACCEPT 2>/dev/null || true
+  echo "🔒 Firewall port $PAC_SERVER_PORT closed"
+}
+
+generate_pac() {
+  local proxy_ip=$(ip route get 1.1.1.1 | awk '{print $7}' | head -1)
+  local pac_file="$(pwd)/proxy.pac"
+
+  cat >"$pac_file" <<EOF
+function FindProxyForURL(url, host) {
+    // Remove port number from host if present
+    var hostNoPort = host.split(':')[0];
+
+    // Direct connection for localhost on the proxy server itself
+    if (hostNoPort == "localhost" || hostNoPort == "127.0.0.1") {
+        return "DIRECT";
+    }
+
+    // Use Privoxy for all traffic
+    return "PROXY ${proxy_ip}:8123; DIRECT";
+}
+EOF
+
+  echo "📄 PAC file generated: $pac_file"
+  echo "🌐 Proxy server IP: $proxy_ip:8123"
+  echo ""
+  echo "🔧 MANUAL PROXY CONFIGURATION:"
+  echo "   HTTP Proxy:  $proxy_ip:8123"
+  echo "   HTTPS Proxy: $proxy_ip:8123"
+  echo "   FTP Proxy:   $proxy_ip:8123"
+  echo "   No proxy for: localhost,127.0.0.1"
+  echo ""
+  echo "💡 AUTOMATIC CONFIGURATION OPTIONS:"
+  echo "   Local file:  file://$pac_file"
+  echo "   HTTP server: http://$proxy_ip:$PAC_SERVER_PORT/proxy.pac"
+}
+
+generate_ca() {
+  if [ ! -f "$PRIVOXY_CA_CERT_FILE" ] || [ ! -f "$PRIVOXY_CA_KEY_FILE" ]; then
+    echo "Generating CA certificate for HTTPS inspection..."
+    openssl req -x509 -newkey rsa:2048 -days 365 -nodes \
+      -keyout "$PRIVOXY_CA_KEY_FILE" \
+      -out "$PRIVOXY_CA_CERT_FILE" \
+      -subj "/CN=Privoxy CA"
+    echo "CA certificate generated at: $PRIVOXY_CA_CERT_FILE"
+  else
+    echo "CA certificate already exists at: $PRIVOXY_CA_CERT_FILE"
+  fi
+}
+
+check_privoxy() {
+  if ! command -v privoxy >/dev/null 2>&1; then
+    echo "❌ Error: privoxy not found in PATH"
+    echo ""
+    echo "🔧 INSTALLATION REQUIRED:"
+    echo ""
+    if [ -f "flake.nix" ] || [ -f "flake.lock" ]; then
+      echo "📦 Nix users: Run 'nix develop' to enter development environment"
+      echo "   Then retry this script"
+    else
+      echo "🐧 Ubuntu/Debian: sudo apt install privoxy"
+      echo "🍎 macOS: brew install privoxy"
+      echo "🔴 RHEL/Fedora: sudo dnf install privoxy"
+      echo "🐧 Arch: sudo pacman -S privoxy"
+    fi
+    echo ""
+    echo "After installation, retry this script"
+    return 1
+  fi
+  return 0
+}
+
+show_logs() {
+  local log_file="$PRIVOXY_CACHE_DIR/privoxy.log"
+
+  if [ ! -f "$log_file" ]; then
+    echo "❌ Log file not found: $log_file"
+    echo "Make sure privoxy is running or has been started at least once."
+    return 1
+  fi
+
+  echo "📋 Following privoxy logs: $log_file"
+  echo "Press Ctrl+C to stop following logs"
+  echo ""
+
+  if command -v tspin >/dev/null 2>&1; then
+    echo "🌀 Using tailspin to follow logs..."
+    tspin "$log_file" --follow
+  elif command -v bat >/dev/null 2>&1; then
+    echo "🦇 Using bat to follow logs..."
+    bat --follow --style=numbers,changes --color=always "$log_file"
+  else
+    echo "📄 Using tail to follow logs (install 'tailspin' or 'bat' for better formatting)..."
+    tail -f "$log_file"
+  fi
 }
 
 show_help() {
-    echo "Usage: $0 {start|stop|restart|status|generate-ca|help}"
-    echo ""
-    echo "Commands:"
-    echo "  start        Start privoxy with HTTPS support"
-    echo "  stop         Stop privoxy"
-    echo "  restart      Restart privoxy"
-    echo "  status       Show privoxy status"
-    echo "  generate-ca  Generate a new CA certificate for HTTPS interception"
-    echo "  help         Show this help message"
-    echo ""
-    echo "The CA certificate is required for HTTPS interception. After running 'generate-ca',"
-    echo "import $PRIVOXY_CA_CERT_FILE into your browser/system to avoid HTTPS warnings."
+  echo "Usage: $0 {start|stop|restart|status|generate-ca|logs|help}"
+  echo ""
+  echo "Commands:"
+  echo "  start        Start privoxy with HTTPS support"
+  echo "  stop         Stop privoxy"
+  echo "  restart      Restart privoxy"
+  echo "  status       Show privoxy status"
+  echo "  generate-ca  Generate a new CA certificate for HTTPS interception"
+  echo "  logs         Follow privoxy logs (uses bat if available, otherwise tail)"
+  echo "  help         Show this help message"
+  echo ""
+  echo "The CA certificate is required for HTTPS interception. After running 'generate-ca',"
+  echo "import $PRIVOXY_CA_CERT_FILE into your browser/system to avoid HTTPS warnings."
 }
 
 case "$CMD" in
-    start)
-        generate_ca
-        if [ ! -f "$PRIVOXY_CONFIG_FILE" ]; then
-            cat >"$PRIVOXY_CONFIG_FILE" <<EOF
-listen-address  127.0.0.1:8123
+start)
+  check_privoxy || exit 1
+  generate_ca
+  if [ ! -f "$PRIVOXY_CONFIG_FILE" ]; then
+    cat >"$PRIVOXY_CONFIG_FILE" <<EOF
+listen-address  0.0.0.0:8123
 logdir $PRIVOXY_CACHE_DIR
 confdir $PRIVOXY_CACHE_DIR
 ca-key-file $PRIVOXY_CA_KEY_FILE
@@ -53,43 +199,51 @@ logfile privoxy.log
 debug   1
 debug   1024
 EOF
-        fi
-        if [ ! -f "$PRIVOXY_PID_FILE" ] || ! kill -0 "$(cat "$PRIVOXY_PID_FILE")" 2>/dev/null; then
-            privoxy --pidfile "$PRIVOXY_PID_FILE" "$PRIVOXY_CONFIG_FILE" &
-            echo $! >"$PRIVOXY_PID_FILE"
-            echo "Started privoxy proxy with HTTPS support on 127.0.0.1:8123 (logdir: $PRIVOXY_CACHE_DIR)"
-        else
-            echo "Privoxy already running (PID: $(cat "$PRIVOXY_PID_FILE"))"
-        fi
-        ;;
-    stop)
-        if [ -f "$PRIVOXY_PID_FILE" ]; then
-            kill "$(cat "$PRIVOXY_PID_FILE")" && rm "$PRIVOXY_PID_FILE"
-            echo "Stopped privoxy."
-        else
-            echo "Privoxy is not running."
-        fi
-        ;;
-    restart)
-        "$0" stop
-        sleep 1
-        "$0" start
-        ;;
-    status)
-        if [ -f "$PRIVOXY_PID_FILE" ] && kill -0 "$(cat "$PRIVOXY_PID_FILE")" 2>/dev/null; then
-            echo "Privoxy is running (PID: $(cat "$PRIVOXY_PID_FILE"))"
-        else
-            echo "Privoxy is not running."
-        fi
-        ;;
-    generate-ca)
-        generate_ca
-        ;;
-    help | --help | -h)
-        show_help
-        ;;
-    *)
-        show_help
-        exit 1
-        ;;
+  fi
+  open_firewall
+  if [ ! -f "$PRIVOXY_PID_FILE" ] || ! kill -0 "$(cat "$PRIVOXY_PID_FILE")" 2>/dev/null; then
+    privoxy --pidfile "$PRIVOXY_PID_FILE" "$PRIVOXY_CONFIG_FILE" &
+    echo $! >"$PRIVOXY_PID_FILE"
+    echo "Started privoxy proxy with HTTPS support on 0.0.0.0:8123 (logdir: $PRIVOXY_CACHE_DIR)"
+  else
+    echo "Privoxy already running (PID: $(cat "$PRIVOXY_PID_FILE"))"
+  fi
+  generate_pac
+  start_pac_server
+  ;;
+stop)
+  if [ -f "$PRIVOXY_PID_FILE" ]; then
+    kill "$(cat "$PRIVOXY_PID_FILE")" && rm "$PRIVOXY_PID_FILE"
+    echo "Stopped privoxy."
+  else
+    echo "Privoxy is not running."
+  fi
+  stop_pac_server
+  close_firewall
+  ;;
+restart)
+  "$0" stop
+  sleep 1
+  "$0" start
+  ;;
+status)
+  if [ -f "$PRIVOXY_PID_FILE" ] && kill -0 "$(cat "$PRIVOXY_PID_FILE")" 2>/dev/null; then
+    echo "Privoxy is running (PID: $(cat "$PRIVOXY_PID_FILE"))"
+  else
+    echo "Privoxy is not running."
+  fi
+  ;;
+generate-ca)
+  generate_ca
+  ;;
+logs)
+  show_logs
+  ;;
+help | --help | -h)
+  show_help
+  ;;
+*)
+  show_help
+  exit 1
+  ;;
 esac

--- a/scripts/privoxy.sh
+++ b/scripts/privoxy.sh
@@ -13,6 +13,12 @@ PAC_SERVER_PORT="8080"
 
 mkdir -p "$PRIVOXY_CACHE_DIR"
 
+# Detect virsh/libvirt bridge IPs for VM testing
+get_virsh_ips() {
+  # Look for virbr* interfaces that are UP and extract their IPv4 addresses
+  ip -4 addr show 2>/dev/null | awk '/virbr[0-9]/ && /inet / {print $2}' | cut -d/ -f1
+}
+
 open_firewall() {
   echo "🔥"
   echo "🔥  SECURITY WARNING: OPENING FIREWALL"
@@ -50,6 +56,9 @@ start_pac_server() {
     cd - >/dev/null
     echo "🌐 PAC server started on port $PAC_SERVER_PORT (PID: $(cat "$PAC_SERVER_PID_FILE"))"
     echo "   PAC URL: http://$proxy_ip:$PAC_SERVER_PORT/proxy.pac"
+    for virsh_ip in $(get_virsh_ips); do
+      echo "   PAC URL (virsh VM): http://$virsh_ip:$PAC_SERVER_PORT/proxy.pac"
+    done
   elif command -v python >/dev/null 2>&1; then
     cd "$(dirname "$pac_file")"
     python -m SimpleHTTPServer "$PAC_SERVER_PORT" >/dev/null 2>&1 &
@@ -57,6 +66,9 @@ start_pac_server() {
     cd - >/dev/null
     echo "🌐 PAC server started on port $PAC_SERVER_PORT (PID: $(cat "$PAC_SERVER_PID_FILE"))"
     echo "   PAC URL: http://$proxy_ip:$PAC_SERVER_PORT/proxy.pac"
+    for virsh_ip in $(get_virsh_ips); do
+      echo "   PAC URL (virsh VM): http://$virsh_ip:$PAC_SERVER_PORT/proxy.pac"
+    done
   else
     echo "⚠️  Warning: Neither python3 nor python found - cannot start PAC server"
     echo "   You'll need to serve the PAC file manually or use file:// URLs"
@@ -106,6 +118,17 @@ EOF
   echo "💡 AUTOMATIC CONFIGURATION OPTIONS:"
   echo "   Local file:  file://$pac_file"
   echo "   HTTP server: http://$proxy_ip:$PAC_SERVER_PORT/proxy.pac"
+  echo ""
+  local virsh_ips
+  virsh_ips=$(get_virsh_ips)
+  if [ -n "$virsh_ips" ]; then
+    echo "🖥️  VIRSH/LIBVIRT VM CONFIGURATION:"
+    echo "   Use these addresses when configuring proxy inside a VM:"
+    for virsh_ip in $virsh_ips; do
+      echo "   HTTP Proxy:  $virsh_ip:8123"
+      echo "   PAC URL:     http://$virsh_ip:$PAC_SERVER_PORT/proxy.pac"
+    done
+  fi
 }
 
 generate_ca() {

--- a/scripts/privoxy.sh
+++ b/scripts/privoxy.sh
@@ -270,6 +270,8 @@ EOF
   fi
   generate_pac
   start_pac_server
+  echo ""
+  echo "📋 To follow logs: $0 logs"
   ;;
 stop)
   if [ -f "$PRIVOXY_PID_FILE" ]; then

--- a/scripts/privoxy.sh
+++ b/scripts/privoxy.sh
@@ -275,7 +275,7 @@ EOF
   ;;
 stop)
   if [ -f "$PRIVOXY_PID_FILE" ]; then
-    kill "$(cat "$PRIVOXY_PID_FILE")" && rm "$PRIVOXY_PID_FILE"
+    kill "$(cat "$PRIVOXY_PID_FILE")" && rm -f "$PRIVOXY_PID_FILE"
     echo "Stopped privoxy."
   else
     echo "Privoxy is not running."


### PR DESCRIPTION
## Summary

- **Use QGIS network stack for API calls** — Replace `requests` session proxy handling with `QgsBlockingNetworkRequest` via a custom `QGISAdapter`, so the plugin respects QGIS proxy settings natively.
- **Add persistent message bar for network errors** — Detect proxy failures, timeouts, and DNS errors; show a Planet-branded persistent message bar that auto-clears when connectivity is restored. Includes `sip.isdeleted()` guard for widget lifecycle safety.
- **Graceful login error handling** — Catch generic exceptions during login so the persistent message bar handles notification instead of crashing.
- **Fix Content-Encoding header access** — Use `.get()` instead of direct key access to avoid `KeyError` when the header is absent.
- **Set objectName on all dock widgets** — Enable QGIS `QMainWindow::saveState()` to persist dock geometry across sessions.
- **Drop QGIS 3.36 from CI** — Remove `release-3_36` from the test matrix.
- **Privoxy dev tooling** — Add virsh/libvirt bridge detection, PAC file test subcommands, log tail hint, and PID file cleanup fix.

## Commits
- `b243d3e` use qgis network stack
- `120543f` Updates to privoxy proxy testing script
- `524fc2a` Bump version to 2.3.6. Added changelog
- `28c9dd4` Dont try to test on 3.36
- `004cd10` Add virsh network detection and PAC URLs to privoxy script
- `1813e2a` Add testpac-local and testpac-vlan subcommands to privoxy script
- `61386e6` Show log tail hint after privoxy start
- `8776758` Fix rm error on privoxy stop when pid file already removed
- `ecc8974` Add persistent message bar for network connectivity errors
- `385b0bf` Fix KeyError when Content-Encoding header is absent
- `5e0be2d` Handle network errors gracefully during login
- `7cf668c` Set objectName on dock widgets for future geometry persistence
- `6ba2add` Update metadata.txt version to 2.3.6
- `2713372` Add SSL/TLS error detection to persistent message bar

## Test plan
- [x] Install plugin in QGIS with proxy configured — verify API calls route through QGIS network stack
- [x] Disconnect network or misconfigure proxy — verify persistent Planet-branded message bar appears
<img width="1615" height="1467" alt="image" src="https://github.com/user-attachments/assets/87be0bd1-46de-4bcb-9433-1141120e9d7f" />

- [x] Restore connectivity — verify message bar auto-clears on next successful request
- [x] Dismiss message bar manually, then trigger clear — verify no RuntimeError crash
- [x] Login with no connectivity — verify graceful handling (no unhandled exception)
- [x] Run CI on supported QGIS versions (3.38, 3.40, 3.42, 3.44)